### PR TITLE
feat: add JsonSchemaExtension metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Currently available:
 * CustomEncoder
 * NoneAsDefaultForOptional (ForceDefaultForOptional)
 * Flatten
+* JsonSchemaExtension
 
 
 ### Alias
@@ -402,6 +403,28 @@ ser.get_json_schema()
 >> {..., 'additionalProperties': False, ...}
 ```
 
+
+### JsonSchemaExtension
+
+`JsonSchemaExtension` allows attaching arbitrary extension fields to the generated JSON Schema via `Annotated`. Multiple extensions on the same type are merged automatically.
+
+```python
+from dataclasses import dataclass
+from typing import Annotated
+from serpyco_rs import Serializer
+from serpyco_rs.metadata import JsonSchemaExtension
+
+@dataclass
+class User:
+    email: Annotated[str, JsonSchemaExtension({"x-custom-tag": "pii"})]
+    name: str
+
+ser = Serializer(User)
+schema = ser.get_json_schema()
+# schema["components"]["schemas"]["User"]["properties"]["email"]["x-custom-tag"] == "pii"
+```
+
+Extensions only affect JSON Schema output — serialization and deserialization behavior is unchanged.
 
 ### Custom encoders for fields
 

--- a/python/serpyco_rs/_describe.py
+++ b/python/serpyco_rs/_describe.py
@@ -71,6 +71,7 @@ from .metadata import (
     Discriminator,
     FieldFormat,
     Format,
+    JsonSchemaExtension,
     KeepNone,
     Max,
     MaxLength,
@@ -149,6 +150,7 @@ class _TypeResolver:
                         state_key=ref,
                         meta=context,
                         custom_encoder=None,
+                        json_schema_extensions=None,
                     ),
                     metadata,
                 )
@@ -169,6 +171,8 @@ class _TypeResolver:
     def _resolve_type(self, t: Any, ref: str) -> BaseType:
         annotations = self.annotations.get()
         custom_encoder = annotations.get(CustomEncoder)
+        json_ext = annotations.get(JsonSchemaExtension)
+        json_schema_extensions = json_ext.schema if json_ext else None
         name = _generate_name(t, ref)
 
         if self.custom_type_resolver and (custom_type := self.custom_type_resolver(t)):
@@ -177,13 +181,17 @@ class _TypeResolver:
                     serialize=custom_type.serialize,
                     deserialize=custom_type.deserialize,
                 )
-            return CustomType(custom_encoder=custom_encoder, json_schema=custom_type.get_json_schema())
+            return CustomType(
+                custom_encoder=custom_encoder,
+                json_schema=custom_type.get_json_schema(),
+                json_schema_extensions=json_schema_extensions,
+            )
 
         if t is Any:
-            return AnyType(custom_encoder=custom_encoder)
+            return AnyType(custom_encoder=custom_encoder, json_schema_extensions=json_schema_extensions)
 
         if t is Never:
-            return NeverType(custom_encoder=custom_encoder)
+            return NeverType(custom_encoder=custom_encoder, json_schema_extensions=json_schema_extensions)
 
         if res := self._match_simple_types(t):
             return res
@@ -202,6 +210,7 @@ class _TypeResolver:
                 min_length=min_length_meta.value if min_length_meta else None,
                 max_length=max_length_meta.value if max_length_meta else None,
                 custom_encoder=custom_encoder,
+                json_schema_extensions=json_schema_extensions,
             )
 
         if origin in {Mapping, dict}:
@@ -210,6 +219,7 @@ class _TypeResolver:
                 value_type=(self.resolve(args[1]) if args else AnyType(custom_encoder=None)),
                 omit_none=annotations.get(NoneFormat, KeepNone).omit,
                 custom_encoder=custom_encoder,
+                json_schema_extensions=json_schema_extensions,
             )
 
         if origin is tuple:
@@ -219,6 +229,7 @@ class _TypeResolver:
                 item_types=[self.resolve(arg) for arg in args],
                 ref_name=name,
                 custom_encoder=custom_encoder,
+                json_schema_extensions=json_schema_extensions,
             )
 
         if dataclasses.is_dataclass(origin) or _is_attrs(origin) or is_typeddict(origin):
@@ -231,7 +242,9 @@ class _TypeResolver:
 
         if _is_literal_type(origin):
             if args and _is_supported_literal_args(args):
-                return LiteralType(args=list(args), custom_encoder=custom_encoder)
+                return LiteralType(
+                    args=list(args), custom_encoder=custom_encoder, json_schema_extensions=json_schema_extensions
+                )
             raise RuntimeError('Supported only Literal[str | int, ...]')
 
         if is_union_type(origin):
@@ -240,6 +253,7 @@ class _TypeResolver:
                 return OptionalType(
                     inner=self.resolve(new_arg),
                     custom_encoder=None,
+                    json_schema_extensions=json_schema_extensions,
                 )
 
             discriminator = annotations.get(Discriminator)
@@ -248,6 +262,7 @@ class _TypeResolver:
                     item_types=[self.resolve(arg) for arg in args],
                     ref_name=name,
                     custom_encoder=custom_encoder,
+                    json_schema_extensions=json_schema_extensions,
                 )
 
             if not all(
@@ -268,6 +283,7 @@ class _TypeResolver:
                     dump_discriminator=discriminator.name,
                     load_discriminator=_apply_format(annotations.get(FieldFormat, NoFormat), discriminator.name),
                     custom_encoder=custom_encoder,
+                    json_schema_extensions=json_schema_extensions,
                 )
 
         if isinstance(t, TypeVar):
@@ -281,6 +297,8 @@ class _TypeResolver:
 
         annotations = self.annotations.get()
         custom_encoder = annotations.get(CustomEncoder)
+        json_ext = annotations.get(JsonSchemaExtension)
+        json_schema_extensions = json_ext.schema if json_ext else None
 
         simple_type_mapping: Mapping[type, type[BaseType]] = {
             bytes: BytesType,
@@ -293,7 +311,7 @@ class _TypeResolver:
         }
 
         if simple := simple_type_mapping.get(t):
-            return simple(custom_encoder=custom_encoder)
+            return simple(custom_encoder=custom_encoder, json_schema_extensions=json_schema_extensions)
 
         number_type_mapping: Mapping[type, type[Union[IntegerType, FloatType]]] = {
             int: IntegerType,
@@ -309,6 +327,7 @@ class _TypeResolver:
                 inclusive_min=min_meta.inclusive if min_meta else True,
                 inclusive_max=max_meta.inclusive if max_meta else True,
                 custom_encoder=custom_encoder,
+                json_schema_extensions=json_schema_extensions,
             )
 
         if t is Decimal:
@@ -320,6 +339,7 @@ class _TypeResolver:
                 inclusive_min=min_meta.inclusive if min_meta else True,
                 inclusive_max=max_meta.inclusive if max_meta else True,
                 custom_encoder=custom_encoder,
+                json_schema_extensions=json_schema_extensions,
             )
 
         if t is str:
@@ -330,10 +350,13 @@ class _TypeResolver:
                 min_length=min_length_meta.value if min_length_meta else None,
                 max_length=max_length_meta.value if max_length_meta else None,
                 custom_encoder=custom_encoder,
+                json_schema_extensions=json_schema_extensions,
             )
 
         if issubclass(t, (Enum, IntEnum)):
-            return EnumType(cls=t, items=list(t), custom_encoder=custom_encoder)
+            return EnumType(
+                cls=t, items=list(t), custom_encoder=custom_encoder, json_schema_extensions=json_schema_extensions
+            )
 
         return None
 
@@ -470,6 +493,9 @@ class _TypeResolver:
             self._validate_flatten_fields(fields, t)
             used_keys = self._compute_used_keys(fields)
 
+            json_ext = cls_annotations.get(JsonSchemaExtension)
+            json_schema_extensions = json_ext.schema if json_ext else None
+
             if is_typeddict(origin):
                 return TypedDictType(
                     name=name,
@@ -478,6 +504,7 @@ class _TypeResolver:
                     doc=t.__doc__,
                     custom_encoder=custom_encoder,
                     used_keys=used_keys,
+                    json_schema_extensions=json_schema_extensions,
                 )
 
             return EntityType(
@@ -489,6 +516,7 @@ class _TypeResolver:
                 doc=_get_dataclass_doc(t),
                 custom_encoder=custom_encoder,
                 used_keys=used_keys,
+                json_schema_extensions=json_schema_extensions,
             )
 
 

--- a/python/serpyco_rs/_impl.pyi
+++ b/python/serpyco_rs/_impl.pyi
@@ -1,4 +1,4 @@
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from enum import Enum, IntEnum
 from typing import Any, Callable, Generic, TypeVar
 
@@ -36,8 +36,13 @@ class CustomEncoder(Generic[_I, _O]):
 
 class BaseType:
     custom_encoder: CustomEncoder[Any, Any] | None
+    json_schema_extensions: Mapping[str, Any] | None
 
-    def __init__(self, custom_encoder: CustomEncoder[Any, Any] | None) -> None: ...
+    def __init__(
+        self,
+        custom_encoder: CustomEncoder[Any, Any] | None = None,
+        json_schema_extensions: Mapping[str, Any] | None = None,
+    ) -> None: ...
 
 class ContainerBaseType(BaseType):
     ref_name: str
@@ -46,10 +51,18 @@ class ContainerBaseType(BaseType):
     def should_use_ref(self) -> bool: ...
 
 class NoneType(BaseType):
-    def __init__(self, custom_encoder: CustomEncoder[Any, Any] | None = None) -> None: ...
+    def __init__(
+        self,
+        custom_encoder: CustomEncoder[Any, Any] | None = None,
+        json_schema_extensions: Mapping[str, Any] | None = None,
+    ) -> None: ...
 
 class NeverType(BaseType):
-    def __init__(self, custom_encoder: CustomEncoder[Any, Any] | None = None) -> None: ...
+    def __init__(
+        self,
+        custom_encoder: CustomEncoder[Any, Any] | None = None,
+        json_schema_extensions: Mapping[str, Any] | None = None,
+    ) -> None: ...
 
 class IntegerType(BaseType):
     min: int | None
@@ -64,6 +77,7 @@ class IntegerType(BaseType):
         inclusive_min: bool = True,
         inclusive_max: bool = True,
         custom_encoder: CustomEncoder[Any, Any] | None = None,
+        json_schema_extensions: Mapping[str, Any] | None = None,
     ) -> None: ...
 
 class FloatType(BaseType):
@@ -79,6 +93,7 @@ class FloatType(BaseType):
         inclusive_min: bool = True,
         inclusive_max: bool = True,
         custom_encoder: CustomEncoder[Any, Any] | None = None,
+        json_schema_extensions: Mapping[str, Any] | None = None,
     ) -> None: ...
 
 class DecimalType(BaseType):
@@ -94,6 +109,7 @@ class DecimalType(BaseType):
         inclusive_min: bool = True,
         inclusive_max: bool = True,
         custom_encoder: CustomEncoder[Any, Any] | None = None,
+        json_schema_extensions: Mapping[str, Any] | None = None,
     ) -> None: ...
 
 class StringType(BaseType):
@@ -105,22 +121,43 @@ class StringType(BaseType):
         min_length: int | None = None,
         max_length: int | None = None,
         custom_encoder: CustomEncoder[Any, Any] | None = None,
+        json_schema_extensions: Mapping[str, Any] | None = None,
     ) -> None: ...
 
 class BooleanType(BaseType):
-    def __init__(self, custom_encoder: CustomEncoder[Any, Any] | None) -> None: ...
+    def __init__(
+        self,
+        custom_encoder: CustomEncoder[Any, Any] | None = None,
+        json_schema_extensions: Mapping[str, Any] | None = None,
+    ) -> None: ...
 
 class UUIDType(BaseType):
-    def __init__(self, custom_encoder: CustomEncoder[Any, Any] | None) -> None: ...
+    def __init__(
+        self,
+        custom_encoder: CustomEncoder[Any, Any] | None = None,
+        json_schema_extensions: Mapping[str, Any] | None = None,
+    ) -> None: ...
 
 class TimeType(BaseType):
-    def __init__(self, custom_encoder: CustomEncoder[Any, Any] | None) -> None: ...
+    def __init__(
+        self,
+        custom_encoder: CustomEncoder[Any, Any] | None = None,
+        json_schema_extensions: Mapping[str, Any] | None = None,
+    ) -> None: ...
 
 class DateTimeType(BaseType):
-    def __init__(self, custom_encoder: CustomEncoder[Any, Any] | None) -> None: ...
+    def __init__(
+        self,
+        custom_encoder: CustomEncoder[Any, Any] | None = None,
+        json_schema_extensions: Mapping[str, Any] | None = None,
+    ) -> None: ...
 
 class DateType(BaseType):
-    def __init__(self, custom_encoder: CustomEncoder[Any, Any] | None) -> None: ...
+    def __init__(
+        self,
+        custom_encoder: CustomEncoder[Any, Any] | None = None,
+        json_schema_extensions: Mapping[str, Any] | None = None,
+    ) -> None: ...
 
 class DefaultValue(Generic[_T]):
     @staticmethod
@@ -176,6 +213,7 @@ class EntityType(BaseType):
         used_keys: set[str] | None = None,
         doc: str | None = None,
         custom_encoder: CustomEncoder[Any, Any] | None = None,
+        json_schema_extensions: Mapping[str, Any] | None = None,
     ) -> None: ...
 
 class TypedDictType(BaseType):
@@ -193,6 +231,7 @@ class TypedDictType(BaseType):
         doc: str | None = None,
         used_keys: set[str] | None = None,
         custom_encoder: CustomEncoder[Any, Any] | None = None,
+        json_schema_extensions: Mapping[str, Any] | None = None,
     ) -> None: ...
 
 class ArrayType(ContainerBaseType):
@@ -207,6 +246,7 @@ class ArrayType(ContainerBaseType):
         min_length: int | None = None,
         max_length: int | None = None,
         custom_encoder: CustomEncoder[Any, Any] | None = None,
+        json_schema_extensions: Mapping[str, Any] | None = None,
     ) -> None: ...
 
 class EnumType(BaseType):
@@ -214,13 +254,22 @@ class EnumType(BaseType):
     items: list[Any]
 
     def __init__(
-        self, cls: type[Enum | IntEnum], items: list[Any], custom_encoder: CustomEncoder[Any, Any] | None = None
+        self,
+        cls: type[Enum | IntEnum],
+        items: list[Any],
+        custom_encoder: CustomEncoder[Any, Any] | None = None,
+        json_schema_extensions: Mapping[str, Any] | None = None,
     ) -> None: ...
 
 class OptionalType(BaseType):
     inner: BaseType
 
-    def __init__(self, inner: BaseType, custom_encoder: CustomEncoder[Any, Any] | None = None) -> None: ...
+    def __init__(
+        self,
+        inner: BaseType,
+        custom_encoder: CustomEncoder[Any, Any] | None = None,
+        json_schema_extensions: Mapping[str, Any] | None = None,
+    ) -> None: ...
 
 class DictionaryType(BaseType):
     key_type: BaseType
@@ -233,6 +282,7 @@ class DictionaryType(BaseType):
         value_type: BaseType,
         omit_none: bool = False,
         custom_encoder: CustomEncoder[Any, Any] | None = None,
+        json_schema_extensions: Mapping[str, Any] | None = None,
     ) -> None: ...
 
 class TupleType(ContainerBaseType):
@@ -243,13 +293,22 @@ class TupleType(ContainerBaseType):
         item_types: list[BaseType],
         ref_name: str,
         custom_encoder: CustomEncoder[Any, Any] | None = None,
+        json_schema_extensions: Mapping[str, Any] | None = None,
     ) -> None: ...
 
 class BytesType(BaseType):
-    def __init__(self, custom_encoder: CustomEncoder[Any, Any] | None = None) -> None: ...
+    def __init__(
+        self,
+        custom_encoder: CustomEncoder[Any, Any] | None = None,
+        json_schema_extensions: Mapping[str, Any] | None = None,
+    ) -> None: ...
 
 class AnyType(BaseType):
-    def __init__(self, custom_encoder: CustomEncoder[Any, Any] | None = None) -> None: ...
+    def __init__(
+        self,
+        custom_encoder: CustomEncoder[Any, Any] | None = None,
+        json_schema_extensions: Mapping[str, Any] | None = None,
+    ) -> None: ...
 
 class UnionType(ContainerBaseType):
     item_types: list[BaseType]
@@ -259,6 +318,7 @@ class UnionType(ContainerBaseType):
         item_types: list[BaseType],
         ref_name: str,
         custom_encoder: CustomEncoder[Any, Any] | None = None,
+        json_schema_extensions: Mapping[str, Any] | None = None,
     ) -> None: ...
 
 class DiscriminatedUnionType(ContainerBaseType):
@@ -273,12 +333,18 @@ class DiscriminatedUnionType(ContainerBaseType):
         load_discriminator: str,
         ref_name: str,
         custom_encoder: CustomEncoder[Any, Any] | None = None,
+        json_schema_extensions: Mapping[str, Any] | None = None,
     ) -> None: ...
 
 class LiteralType(BaseType):
     args: list[str | int | Enum]
 
-    def __init__(self, args: list[str | int | Enum], custom_encoder: CustomEncoder[Any, Any] | None = None) -> None: ...
+    def __init__(
+        self,
+        args: list[str | int | Enum],
+        custom_encoder: CustomEncoder[Any, Any] | None = None,
+        json_schema_extensions: Mapping[str, Any] | None = None,
+    ) -> None: ...
 
 class RecursionHolder(BaseType):
     name: str
@@ -286,11 +352,21 @@ class RecursionHolder(BaseType):
     meta: ResolverContext
 
     def __init__(
-        self, name: str, state_key: str, meta: ResolverContext, custom_encoder: CustomEncoder[Any, Any] | None = None
+        self,
+        name: str,
+        state_key: str,
+        meta: ResolverContext,
+        custom_encoder: CustomEncoder[Any, Any] | None = None,
+        json_schema_extensions: Mapping[str, Any] | None = None,
     ) -> None: ...
     def get_inner_type(self) -> BaseType: ...
 
 class CustomType(BaseType):
     json_schema: dict[str, Any]
 
-    def __init__(self, custom_encoder: CustomEncoder[Any, Any], json_schema: dict[str, Any]) -> None: ...
+    def __init__(
+        self,
+        custom_encoder: CustomEncoder[Any, Any],
+        json_schema: dict[str, Any],
+        json_schema_extensions: Mapping[str, Any] | None = None,
+    ) -> None: ...

--- a/python/serpyco_rs/_json_schema/_convert.py
+++ b/python/serpyco_rs/_json_schema/_convert.py
@@ -71,18 +71,29 @@ def to_json_schema(_: Any, doc: Optional[str] = None, *, config: Config) -> Sche
 
 @to_json_schema.register
 def _(arg: describe.StringType, doc: Optional[str] = None, *, config: Config) -> Schema:
-    return StringType(minLength=arg.min_length, maxLength=arg.max_length, description=doc, config=config)
+    return StringType(
+        minLength=arg.min_length,
+        maxLength=arg.max_length,
+        description=doc,
+        config=config,
+        json_schema_extensions=arg.json_schema_extensions,
+    )
 
 
 @to_json_schema.register
 def _(arg: describe.NoneType, doc: Optional[str] = None, *, config: Config) -> Schema:
-    return Null(config=config)
+    return Null(config=config, json_schema_extensions=arg.json_schema_extensions)
 
 
 @to_json_schema.register
 def _(arg: describe.NeverType, doc: Optional[str] = None, *, config: Config) -> Schema:
     # Never type in JSON Schema is represented as a schema that matches nothing
-    return Schema(additionalArgs={'not': {}}, description=doc, config=config)
+    return Schema(
+        additionalArgs={'not': {}},
+        description=doc,
+        config=config,
+        json_schema_extensions=arg.json_schema_extensions,
+    )
 
 
 @to_json_schema.register
@@ -94,12 +105,18 @@ def _(arg: describe.IntegerType, doc: Optional[str] = None, *, config: Config) -
         exclusiveMaximum=arg.max if not arg.inclusive_max else None,
         description=doc,
         config=config,
+        json_schema_extensions=arg.json_schema_extensions,
     )
 
 
 @to_json_schema.register
-def _(_: describe.BytesType, doc: Optional[str] = None, *, config: Config) -> Schema:
-    return StringType(format='binary', description=doc, config=config)
+def _(arg: describe.BytesType, doc: Optional[str] = None, *, config: Config) -> Schema:
+    return StringType(
+        format='binary',
+        description=doc,
+        config=config,
+        json_schema_extensions=arg.json_schema_extensions,
+    )
 
 
 @to_json_schema.register
@@ -111,11 +128,12 @@ def _(arg: describe.FloatType, doc: Optional[str] = None, *, config: Config) -> 
         exclusiveMaximum=arg.max if not arg.inclusive_max else None,
         description=doc,
         config=config,
+        json_schema_extensions=arg.json_schema_extensions,
     )
 
 
 @to_json_schema.register
-def _(_: describe.DecimalType, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(arg: describe.DecimalType, doc: Optional[str] = None, *, config: Config) -> Schema:
     # todo: support min/max
     return Schema(
         oneOf=[
@@ -124,32 +142,35 @@ def _(_: describe.DecimalType, doc: Optional[str] = None, *, config: Config) -> 
         ],
         description=doc,
         config=config,
+        json_schema_extensions=arg.json_schema_extensions,
     )
 
 
 @to_json_schema.register
-def _(_: describe.BooleanType, doc: Optional[str] = None, *, config: Config) -> Schema:
-    return Boolean(config=config, description=doc)
+def _(arg: describe.BooleanType, doc: Optional[str] = None, *, config: Config) -> Schema:
+    return Boolean(config=config, description=doc, json_schema_extensions=arg.json_schema_extensions)
 
 
 @to_json_schema.register
-def _(_: describe.UUIDType, doc: Optional[str] = None, *, config: Config) -> Schema:
-    return StringType(format='uuid', description=doc, config=config)
+def _(arg: describe.UUIDType, doc: Optional[str] = None, *, config: Config) -> Schema:
+    return StringType(format='uuid', description=doc, config=config, json_schema_extensions=arg.json_schema_extensions)
 
 
 @to_json_schema.register
-def _(_: describe.TimeType, doc: Optional[str] = None, *, config: Config) -> Schema:
-    return StringType(format='time', description=doc, config=config)
+def _(arg: describe.TimeType, doc: Optional[str] = None, *, config: Config) -> Schema:
+    return StringType(format='time', description=doc, config=config, json_schema_extensions=arg.json_schema_extensions)
 
 
 @to_json_schema.register
-def _(_: describe.DateTimeType, doc: Optional[str] = None, *, config: Config) -> Schema:
-    return StringType(format='date-time', description=doc, config=config)
+def _(arg: describe.DateTimeType, doc: Optional[str] = None, *, config: Config) -> Schema:
+    return StringType(
+        format='date-time', description=doc, config=config, json_schema_extensions=arg.json_schema_extensions
+    )
 
 
 @to_json_schema.register
-def _(_: describe.DateType, doc: Optional[str] = None, *, config: Config) -> Schema:
-    return StringType(format='date', description=doc, config=config)
+def _(arg: describe.DateType, doc: Optional[str] = None, *, config: Config) -> Schema:
+    return StringType(format='date', description=doc, config=config, json_schema_extensions=arg.json_schema_extensions)
 
 
 @to_json_schema.register
@@ -166,6 +187,7 @@ def _(arg: describe.EnumType, doc: Optional[str] = None, *, config: Config) -> S
         description=doc,
         config=config,
         additionalArgs={f'x-{item.value}': docs.get(item.name) for item in arg.items},
+        json_schema_extensions=arg.json_schema_extensions,
     )
 
 
@@ -178,6 +200,7 @@ def _(arg: describe.OptionalType, doc: Optional[str] = None, *, config: Config) 
         ],
         description=doc,
         config=config,
+        json_schema_extensions=arg.json_schema_extensions,
     )
 
 
@@ -212,6 +235,7 @@ def _(arg: describe.EntityType, doc: Optional[str] = None, *, config: Config) ->
         description=arg.doc,
         config=config,
         additionalProperties=dict_flatten_additional_properties,
+        json_schema_extensions=arg.json_schema_extensions,
     )
 
 
@@ -223,6 +247,7 @@ def _(arg: describe.TypedDictType, doc: Optional[str] = None, *, config: Config)
         name=arg.name,
         description=arg.doc,
         config=config,
+        json_schema_extensions=arg.json_schema_extensions,
     )
 
 
@@ -234,6 +259,7 @@ def _(arg: describe.ArrayType, doc: Optional[str] = None, *, config: Config) -> 
         maxItems=arg.max_length,
         description=doc,
         config=config,
+        json_schema_extensions=arg.json_schema_extensions,
     )
 
     if arg.should_use_ref():
@@ -244,7 +270,10 @@ def _(arg: describe.ArrayType, doc: Optional[str] = None, *, config: Config) -> 
 @to_json_schema.register
 def _(arg: describe.DictionaryType, doc: Optional[str] = None, *, config: Config) -> Schema:
     return ObjectType(
-        additionalProperties=to_json_schema(arg.value_type, config=config), description=doc, config=config
+        additionalProperties=to_json_schema(arg.value_type, config=config),
+        description=doc,
+        config=config,
+        json_schema_extensions=arg.json_schema_extensions,
     )
 
 
@@ -256,6 +285,7 @@ def _(arg: describe.TupleType, doc: Optional[str] = None, *, config: Config) -> 
         maxItems=len(arg.item_types),
         description=doc,
         config=config,
+        json_schema_extensions=arg.json_schema_extensions,
     )
     if arg.should_use_ref():
         return RefType(description=doc, name=arg.ref_name, definition=schema, config=config)
@@ -263,13 +293,15 @@ def _(arg: describe.TupleType, doc: Optional[str] = None, *, config: Config) -> 
 
 
 @to_json_schema.register
-def _(_: describe.AnyType, doc: Optional[str] = None, *, config: Config) -> Schema:
-    return Schema(description=doc, config=config)
+def _(arg: describe.AnyType, doc: Optional[str] = None, *, config: Config) -> Schema:
+    return Schema(description=doc, config=config, json_schema_extensions=arg.json_schema_extensions)
 
 
 @to_json_schema.register
 def _(holder: describe.RecursionHolder, doc: Optional[str] = None, *, config: Config) -> Schema:
-    return RefType(description=doc, name=holder.name, config=config)
+    return RefType(
+        description=doc, name=holder.name, config=config, json_schema_extensions=holder.json_schema_extensions
+    )
 
 
 @to_json_schema.register
@@ -278,6 +310,7 @@ def _(arg: describe.LiteralType, doc: Optional[str] = None, *, config: Config) -
         enum=[arg.value if isinstance(arg, Enum) else arg for arg in arg.args],
         description=doc,
         config=config,
+        json_schema_extensions=arg.json_schema_extensions,
     )
 
 
@@ -287,6 +320,7 @@ def _(arg: describe.UnionType, doc: Optional[str] = None, *, config: Config) -> 
         anyOf=[to_json_schema(t, config=config) for t in arg.item_types],
         description=doc,
         config=config,
+        json_schema_extensions=arg.json_schema_extensions,
     )
 
     if arg.should_use_ref():
@@ -311,6 +345,7 @@ def _(arg: describe.DiscriminatedUnionType, doc: Optional[str] = None, *, config
         ),
         description=doc,
         config=config,
+        json_schema_extensions=arg.json_schema_extensions,
     )
     if arg.should_use_ref():
         return RefType(description=doc, name=arg.ref_name, definition=schema, config=config)
@@ -326,4 +361,9 @@ def _check_unions_schema_types(schema: Schema) -> TypeGuard[Union[ObjectType, Re
 
 @to_json_schema.register
 def _(arg: describe.CustomType, doc: Optional[str] = None, *, config: Config) -> Schema:
-    return Schema(additionalArgs=arg.json_schema, description=doc, config=config)
+    return Schema(
+        additionalArgs=arg.json_schema,
+        description=doc,
+        config=config,
+        json_schema_extensions=arg.json_schema_extensions,
+    )

--- a/python/serpyco_rs/_json_schema/_entities.py
+++ b/python/serpyco_rs/_json_schema/_entities.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -25,6 +26,7 @@ class Schema:
     anyOf: list[Schema] | None = None
     oneOf: list[Schema] | None = None
     additionalArgs: dict[str, Any] | None = None
+    json_schema_extensions: Mapping[str, Any] | None = None
 
     def dump(self, definitions: dict[str, Any]) -> dict[str, Any]:
         data = {
@@ -38,7 +40,10 @@ class Schema:
             'oneOf': [item.dump(definitions) for item in self.oneOf] if self.oneOf else None,
             **(self.additionalArgs or {}),
         }
-        return {k: v for k, v in data.items() if v is not None}
+        data = {k: v for k, v in data.items() if v is not None}
+        if self.json_schema_extensions:
+            data.update(self.json_schema_extensions)
+        return data
 
 
 @dataclass
@@ -118,6 +123,8 @@ class ObjectType(Schema):
             **data,
         }
         data = {k: v for k, v in data.items() if v is not None}
+        if self.json_schema_extensions:
+            data.update(self.json_schema_extensions)
         if not self.name:
             return data
         definitions[self.name] = data

--- a/python/serpyco_rs/_secial_forms.py
+++ b/python/serpyco_rs/_secial_forms.py
@@ -7,6 +7,7 @@ from typing import Annotated, Any, ClassVar, Final, ForwardRef, Union, get_origi
 from typing_extensions import NotRequired, ReadOnly, Required, get_args
 
 from ._meta import Annotations
+from .metadata import JsonSchemaExtension
 
 
 if sys.version_info >= (3, 12):
@@ -72,6 +73,14 @@ def unwrap_special_forms(annotation: Any) -> tuple[Any, Annotations]:
                 break
         else:
             break
+
+    json_schema_extensions: dict[str, Any] = {}
+    for item in metadata:
+        if isinstance(item, JsonSchemaExtension):
+            json_schema_extensions.update(item.schema)
+    if json_schema_extensions:
+        metadata = [m for m in metadata if not isinstance(m, JsonSchemaExtension)]
+        metadata.append(JsonSchemaExtension(json_schema_extensions))
 
     return annotation, Annotations(*metadata)
 

--- a/python/serpyco_rs/metadata.py
+++ b/python/serpyco_rs/metadata.py
@@ -1,7 +1,7 @@
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from enum import Enum
-from typing import TypeVar, Union
+from typing import Any, TypeVar, Union
 
 from ._impl import CustomEncoder
 
@@ -80,6 +80,23 @@ def serialize_with(func: Callable[[_I], _O]) -> CustomEncoder[_I, _O]:
 
 def deserialize_with(func: Callable[[_O], _I]) -> CustomEncoder[_I, _O]:
     return CustomEncoder[_I, _O](deserialize=func)
+
+
+class JsonSchemaExtension:
+    def __init__(self, schema: Mapping[str, Any]) -> None:
+        self._pairs = tuple(sorted(schema.items()))
+        self.schema: Mapping[str, Any] = dict(self._pairs)
+
+    def __hash__(self) -> int:
+        return hash(self._pairs)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, JsonSchemaExtension):
+            return self.schema == other.schema
+        return NotImplemented
+
+    def __str__(self) -> str:
+        return f'JsonSchemaExtension(schema={self.schema})'
 
 
 @dataclass(frozen=True)

--- a/src/validator/types.rs
+++ b/src/validator/types.rs
@@ -19,28 +19,44 @@ macro_rules! py_eq {
 pub struct BaseType {
     #[pyo3(get)]
     pub custom_encoder: Option<Py<PyAny>>,
+    #[pyo3(get)]
+    pub json_schema_extensions: Option<Py<PyDict>>,
 }
 
 #[pymethods]
 impl BaseType {
     #[new]
-    #[pyo3(signature = (custom_encoder=None))]
-    fn new(custom_encoder: Option<&Bound<'_, PyAny>>) -> PyClassInitializer<Self> {
+    #[pyo3(signature = (custom_encoder=None, json_schema_extensions=None))]
+    fn new(
+        custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
+    ) -> PyClassInitializer<Self> {
         PyClassInitializer::from(BaseType {
             custom_encoder: custom_encoder.map(|x| x.clone().unbind()),
+            json_schema_extensions: json_schema_extensions.map(|x| x.clone().unbind()),
         })
     }
 
     fn __repr__(&self) -> String {
-        format!("<Type: custom_encoder={:?}>", self.custom_encoder)
+        format!(
+            "<Type: custom_encoder={:?}, json_schema_extensions={:?}>",
+            self.custom_encoder, self.json_schema_extensions
+        )
     }
 
     fn __eq__(&self, other: &Self, py: Python<'_>) -> PyResult<bool> {
-        match (&self.custom_encoder, &other.custom_encoder) {
-            (Some(a), Some(b)) => Ok(py_eq!(a, b, py)),
-            (None, None) => Ok(true),
-            _ => Ok(false),
-        }
+        let custom_encoder_eq = match (&self.custom_encoder, &other.custom_encoder) {
+            (Some(a), Some(b)) => py_eq!(a, b, py),
+            (None, None) => true,
+            _ => false,
+        };
+        let json_schema_extensions_eq =
+            match (&self.json_schema_extensions, &other.json_schema_extensions) {
+                (Some(a), Some(b)) => py_eq!(a, b, py),
+                (None, None) => true,
+                _ => false,
+            };
+        Ok(custom_encoder_eq && json_schema_extensions_eq)
     }
 }
 
@@ -64,8 +80,12 @@ pub struct ContainerBaseType {
 #[pymethods]
 impl ContainerBaseType {
     #[new]
-    fn new(ref_name: &str, custom_encoder: Option<&Bound<'_, PyAny>>) -> PyClassInitializer<Self> {
-        BaseType::new(custom_encoder).add_subclass(ContainerBaseType {
+    fn new(
+        ref_name: &str,
+        custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
+    ) -> PyClassInitializer<Self> {
+        BaseType::new(custom_encoder, json_schema_extensions).add_subclass(ContainerBaseType {
             usage_counter: UsageCounter(AtomicUsize::new(0)),
             ref_name: ref_name.to_string(),
         })
@@ -128,9 +148,12 @@ pub struct NoneType {}
 #[pymethods]
 impl NoneType {
     #[new]
-    #[pyo3(signature = (custom_encoder=None))]
-    fn new(custom_encoder: Option<&Bound<'_, PyAny>>) -> PyClassInitializer<Self> {
-        BaseType::new(custom_encoder).add_subclass(Self {})
+    #[pyo3(signature = (custom_encoder=None, json_schema_extensions=None))]
+    fn new(
+        custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
+    ) -> PyClassInitializer<Self> {
+        BaseType::new(custom_encoder, json_schema_extensions).add_subclass(Self {})
     }
 
     fn __eq__(self_: PyRef<'_, Self>, other: PyRef<'_, Self>, py: Python<'_>) -> PyResult<bool> {
@@ -151,9 +174,12 @@ pub struct NeverType {}
 #[pymethods]
 impl NeverType {
     #[new]
-    #[pyo3(signature = (custom_encoder=None))]
-    fn new(custom_encoder: Option<&Bound<'_, PyAny>>) -> PyClassInitializer<Self> {
-        BaseType::new(custom_encoder).add_subclass(Self {})
+    #[pyo3(signature = (custom_encoder=None, json_schema_extensions=None))]
+    fn new(
+        custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
+    ) -> PyClassInitializer<Self> {
+        BaseType::new(custom_encoder, json_schema_extensions).add_subclass(Self {})
     }
 
     fn __eq__(self_: PyRef<'_, Self>, other: PyRef<'_, Self>, py: Python<'_>) -> PyResult<bool> {
@@ -183,15 +209,16 @@ pub struct IntegerType {
 #[pymethods]
 impl IntegerType {
     #[new]
-    #[pyo3(signature = (min=None, max=None, inclusive_min=true, inclusive_max=true, custom_encoder=None))]
+    #[pyo3(signature = (min=None, max=None, inclusive_min=true, inclusive_max=true, custom_encoder=None, json_schema_extensions=None))]
     fn new(
         min: Option<i64>,
         max: Option<i64>,
         inclusive_min: bool,
         inclusive_max: bool,
         custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
     ) -> PyClassInitializer<Self> {
-        BaseType::new(custom_encoder).add_subclass(Self {
+        BaseType::new(custom_encoder, json_schema_extensions).add_subclass(Self {
             min,
             max,
             inclusive_min,
@@ -233,15 +260,16 @@ pub struct FloatType {
 #[pymethods]
 impl FloatType {
     #[new]
-    #[pyo3(signature = (min=None, max=None, inclusive_min=true, inclusive_max=true, custom_encoder=None))]
+    #[pyo3(signature = (min=None, max=None, inclusive_min=true, inclusive_max=true, custom_encoder=None, json_schema_extensions=None))]
     fn new(
         min: Option<f64>,
         max: Option<f64>,
         inclusive_min: bool,
         inclusive_max: bool,
         custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
     ) -> PyClassInitializer<Self> {
-        BaseType::new(custom_encoder).add_subclass(Self {
+        BaseType::new(custom_encoder, json_schema_extensions).add_subclass(Self {
             min,
             max,
             inclusive_min,
@@ -283,15 +311,16 @@ pub struct DecimalType {
 #[pymethods]
 impl DecimalType {
     #[new]
-    #[pyo3(signature = (min=None, max=None, inclusive_min=true, inclusive_max=true, custom_encoder=None))]
+    #[pyo3(signature = (min=None, max=None, inclusive_min=true, inclusive_max=true, custom_encoder=None, json_schema_extensions=None))]
     fn new(
         min: Option<f64>,
         max: Option<f64>,
         inclusive_min: bool,
         inclusive_max: bool,
         custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
     ) -> PyClassInitializer<Self> {
-        BaseType::new(custom_encoder).add_subclass(Self {
+        BaseType::new(custom_encoder, json_schema_extensions).add_subclass(Self {
             min,
             max,
             inclusive_min,
@@ -329,13 +358,14 @@ pub struct StringType {
 #[pymethods]
 impl StringType {
     #[new]
-    #[pyo3(signature = (min_length=None, max_length=None, custom_encoder=None))]
+    #[pyo3(signature = (min_length=None, max_length=None, custom_encoder=None, json_schema_extensions=None))]
     fn new(
         min_length: Option<usize>,
         max_length: Option<usize>,
         custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
     ) -> PyClassInitializer<Self> {
-        BaseType::new(custom_encoder).add_subclass(Self {
+        BaseType::new(custom_encoder, json_schema_extensions).add_subclass(Self {
             min_length,
             max_length,
         })
@@ -364,9 +394,12 @@ pub struct BooleanType {}
 #[pymethods]
 impl BooleanType {
     #[new]
-    #[pyo3(signature = (custom_encoder=None))]
-    fn new(custom_encoder: Option<&Bound<'_, PyAny>>) -> PyClassInitializer<Self> {
-        BaseType::new(custom_encoder).add_subclass(Self {})
+    #[pyo3(signature = (custom_encoder=None, json_schema_extensions=None))]
+    fn new(
+        custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
+    ) -> PyClassInitializer<Self> {
+        BaseType::new(custom_encoder, json_schema_extensions).add_subclass(Self {})
     }
 
     fn __eq__(self_: PyRef<'_, Self>, other: PyRef<'_, Self>, py: Python<'_>) -> PyResult<bool> {
@@ -387,9 +420,12 @@ pub struct UUIDType {}
 #[pymethods]
 impl UUIDType {
     #[new]
-    #[pyo3(signature = (custom_encoder=None))]
-    fn new(custom_encoder: Option<&Bound<'_, PyAny>>) -> PyClassInitializer<Self> {
-        BaseType::new(custom_encoder).add_subclass(Self {})
+    #[pyo3(signature = (custom_encoder=None, json_schema_extensions=None))]
+    fn new(
+        custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
+    ) -> PyClassInitializer<Self> {
+        BaseType::new(custom_encoder, json_schema_extensions).add_subclass(Self {})
     }
 
     fn __eq__(self_: PyRef<'_, Self>, other: PyRef<'_, Self>, py: Python<'_>) -> PyResult<bool> {
@@ -410,9 +446,12 @@ pub struct TimeType {}
 #[pymethods]
 impl TimeType {
     #[new]
-    #[pyo3(signature = (custom_encoder=None))]
-    fn new(custom_encoder: Option<&Bound<'_, PyAny>>) -> PyClassInitializer<Self> {
-        BaseType::new(custom_encoder).add_subclass(Self {})
+    #[pyo3(signature = (custom_encoder=None, json_schema_extensions=None))]
+    fn new(
+        custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
+    ) -> PyClassInitializer<Self> {
+        BaseType::new(custom_encoder, json_schema_extensions).add_subclass(Self {})
     }
 
     fn __eq__(self_: PyRef<'_, Self>, other: PyRef<'_, Self>, py: Python<'_>) -> PyResult<bool> {
@@ -433,9 +472,12 @@ pub struct DateTimeType {}
 #[pymethods]
 impl DateTimeType {
     #[new]
-    #[pyo3(signature = (custom_encoder=None))]
-    fn new(custom_encoder: Option<&Bound<'_, PyAny>>) -> PyClassInitializer<Self> {
-        BaseType::new(custom_encoder).add_subclass(Self {})
+    #[pyo3(signature = (custom_encoder=None, json_schema_extensions=None))]
+    fn new(
+        custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
+    ) -> PyClassInitializer<Self> {
+        BaseType::new(custom_encoder, json_schema_extensions).add_subclass(Self {})
     }
 
     fn __eq__(self_: PyRef<'_, Self>, other: PyRef<'_, Self>, py: Python<'_>) -> PyResult<bool> {
@@ -456,9 +498,12 @@ pub struct DateType {}
 #[pymethods]
 impl DateType {
     #[new]
-    #[pyo3(signature = (custom_encoder=None))]
-    fn new(custom_encoder: Option<&Bound<'_, PyAny>>) -> PyClassInitializer<Self> {
-        BaseType::new(custom_encoder).add_subclass(Self {})
+    #[pyo3(signature = (custom_encoder=None, json_schema_extensions=None))]
+    fn new(
+        custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
+    ) -> PyClassInitializer<Self> {
+        BaseType::new(custom_encoder, json_schema_extensions).add_subclass(Self {})
     }
 
     fn __eq__(self_: PyRef<'_, Self>, other: PyRef<'_, Self>, py: Python<'_>) -> PyResult<bool> {
@@ -559,7 +604,7 @@ pub struct EntityType {
 #[pymethods]
 impl EntityType {
     #[new]
-    #[pyo3(signature = (cls, name, fields, omit_none=false, is_frozen=false, used_keys=None, doc=None, custom_encoder=None))]
+    #[pyo3(signature = (cls, name, fields, omit_none=false, is_frozen=false, used_keys=None, doc=None, custom_encoder=None, json_schema_extensions=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         cls: &Bound<'_, PyAny>,
@@ -570,9 +615,10 @@ impl EntityType {
         used_keys: Option<&Bound<'_, PySet>>,
         doc: Option<&Bound<'_, PyAny>>,
         custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
         py: Python<'_>,
     ) -> PyClassInitializer<Self> {
-        BaseType::new(custom_encoder).add_subclass(EntityType {
+        BaseType::new(custom_encoder, json_schema_extensions).add_subclass(EntityType {
             cls: cls.clone().unbind(),
             name: name.clone().unbind(),
             fields,
@@ -642,7 +688,8 @@ pub struct TypedDictType {
 #[pymethods]
 impl TypedDictType {
     #[new]
-    #[pyo3(signature = (name, fields, omit_none=false, doc=None, used_keys=None, custom_encoder=None))]
+    #[pyo3(signature = (name, fields, omit_none=false, doc=None, used_keys=None, custom_encoder=None, json_schema_extensions=None))]
+    #[allow(clippy::too_many_arguments)]
     fn new(
         name: &Bound<'_, PyAny>,
         fields: Vec<EntityField>,
@@ -650,9 +697,10 @@ impl TypedDictType {
         doc: Option<&Bound<'_, PyAny>>,
         used_keys: Option<&Bound<'_, PySet>>,
         custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
         py: Python<'_>,
     ) -> PyClassInitializer<Self> {
-        BaseType::new(custom_encoder).add_subclass(TypedDictType {
+        BaseType::new(custom_encoder, json_schema_extensions).add_subclass(TypedDictType {
             name: name.clone().unbind(),
             fields,
             omit_none,
@@ -782,19 +830,22 @@ pub struct ArrayType {
 #[pymethods]
 impl ArrayType {
     #[new]
-    #[pyo3(signature = (item_type, ref_name, min_length=None, max_length=None, custom_encoder=None))]
+    #[pyo3(signature = (item_type, ref_name, min_length=None, max_length=None, custom_encoder=None, json_schema_extensions=None))]
     fn new(
         item_type: &Bound<'_, PyAny>,
         ref_name: String,
         min_length: Option<usize>,
         max_length: Option<usize>,
         custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
     ) -> PyClassInitializer<Self> {
-        ContainerBaseType::new(&ref_name, custom_encoder).add_subclass(ArrayType {
-            item_type: item_type.clone().unbind(),
-            min_length,
-            max_length,
-        })
+        ContainerBaseType::new(&ref_name, custom_encoder, json_schema_extensions).add_subclass(
+            ArrayType {
+                item_type: item_type.clone().unbind(),
+                min_length,
+                max_length,
+            },
+        )
     }
 
     fn __eq__(self_: PyRef<'_, Self>, other: PyRef<'_, Self>, py: Python<'_>) -> PyResult<bool> {
@@ -833,11 +884,12 @@ pub struct EnumType {
 #[pymethods]
 impl EnumType {
     #[new]
-    #[pyo3(signature = (cls, items, custom_encoder=None))]
+    #[pyo3(signature = (cls, items, custom_encoder=None, json_schema_extensions=None))]
     fn new(
         cls: &Bound<'_, PyAny>,
         items: &Bound<'_, PyList>,
         custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<PyClassInitializer<Self>> {
         let load_map = PyDict::new(cls.py());
         let mut dump_map = IntMap::default();
@@ -860,13 +912,15 @@ impl EnumType {
             }
         }
 
-        Ok(BaseType::new(custom_encoder).add_subclass(EnumType {
-            cls: cls.clone().unbind(),
-            items: items.clone().unbind(),
-            items_repr: format!("[{}]", items_repr.join(", ")),
-            load_map: load_map.unbind(),
-            dump_map,
-        }))
+        Ok(
+            BaseType::new(custom_encoder, json_schema_extensions).add_subclass(EnumType {
+                cls: cls.clone().unbind(),
+                items: items.clone().unbind(),
+                items_repr: format!("[{}]", items_repr.join(", ")),
+                load_map: load_map.unbind(),
+                dump_map,
+            }),
+        )
     }
 
     fn __eq__(self_: PyRef<'_, Self>, other: PyRef<'_, Self>, py: Python<'_>) -> PyResult<bool> {
@@ -896,12 +950,13 @@ pub struct OptionalType {
 #[pymethods]
 impl OptionalType {
     #[new]
-    #[pyo3(signature = (inner, custom_encoder=None))]
+    #[pyo3(signature = (inner, custom_encoder=None, json_schema_extensions=None))]
     fn new(
         inner: &Bound<'_, PyAny>,
         custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
     ) -> PyClassInitializer<Self> {
-        BaseType::new(custom_encoder).add_subclass(Self {
+        BaseType::new(custom_encoder, json_schema_extensions).add_subclass(Self {
             inner: inner.clone().unbind(),
         })
     }
@@ -931,14 +986,15 @@ pub struct DictionaryType {
 #[pymethods]
 impl DictionaryType {
     #[new]
-    #[pyo3(signature = (key_type, value_type, omit_none=false, custom_encoder=None))]
+    #[pyo3(signature = (key_type, value_type, omit_none=false, custom_encoder=None, json_schema_extensions=None))]
     fn new(
         key_type: &Bound<'_, PyAny>,
         value_type: &Bound<'_, PyAny>,
         omit_none: bool,
         custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
     ) -> PyClassInitializer<Self> {
-        BaseType::new(custom_encoder).add_subclass(DictionaryType {
+        BaseType::new(custom_encoder, json_schema_extensions).add_subclass(DictionaryType {
             key_type: key_type.clone().unbind(),
             value_type: value_type.clone().unbind(),
             omit_none,
@@ -974,15 +1030,18 @@ pub struct TupleType {
 #[pymethods]
 impl TupleType {
     #[new]
-    #[pyo3(signature = (item_types, ref_name, custom_encoder=None))]
+    #[pyo3(signature = (item_types, ref_name, custom_encoder=None, json_schema_extensions=None))]
     fn new(
         item_types: Vec<Bound<'_, PyAny>>,
         ref_name: String,
         custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
     ) -> PyClassInitializer<Self> {
-        ContainerBaseType::new(&ref_name, custom_encoder).add_subclass(TupleType {
-            item_types: item_types.into_iter().map(|x| x.unbind()).collect(),
-        })
+        ContainerBaseType::new(&ref_name, custom_encoder, json_schema_extensions).add_subclass(
+            TupleType {
+                item_types: item_types.into_iter().map(|x| x.unbind()).collect(),
+            },
+        )
     }
 
     fn __eq__(self_: PyRef<'_, Self>, other: PyRef<'_, Self>, py: Python<'_>) -> PyResult<bool> {
@@ -1015,9 +1074,12 @@ pub struct BytesType {}
 #[pymethods]
 impl BytesType {
     #[new]
-    #[pyo3(signature = (custom_encoder=None))]
-    fn new(custom_encoder: Option<&Bound<'_, PyAny>>) -> PyClassInitializer<Self> {
-        BaseType::new(custom_encoder).add_subclass(BytesType {})
+    #[pyo3(signature = (custom_encoder=None, json_schema_extensions=None))]
+    fn new(
+        custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
+    ) -> PyClassInitializer<Self> {
+        BaseType::new(custom_encoder, json_schema_extensions).add_subclass(BytesType {})
     }
 
     fn __eq__(self_: PyRef<'_, Self>, other: PyRef<'_, Self>, py: Python<'_>) -> PyResult<bool> {
@@ -1038,9 +1100,12 @@ pub struct AnyType {}
 #[pymethods]
 impl AnyType {
     #[new]
-    #[pyo3(signature = (custom_encoder=None))]
-    fn new(custom_encoder: Option<&Bound<'_, PyAny>>) -> PyClassInitializer<Self> {
-        BaseType::new(custom_encoder).add_subclass(AnyType {})
+    #[pyo3(signature = (custom_encoder=None, json_schema_extensions=None))]
+    fn new(
+        custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
+    ) -> PyClassInitializer<Self> {
+        BaseType::new(custom_encoder, json_schema_extensions).add_subclass(AnyType {})
     }
 
     fn __eq__(self_: PyRef<'_, Self>, other: PyRef<'_, Self>, py: Python<'_>) -> PyResult<bool> {
@@ -1068,19 +1133,22 @@ pub struct DiscriminatedUnionType {
 #[pymethods]
 impl DiscriminatedUnionType {
     #[new]
-    #[pyo3(signature = (item_types, dump_discriminator, load_discriminator, ref_name, custom_encoder=None))]
+    #[pyo3(signature = (item_types, dump_discriminator, load_discriminator, ref_name, custom_encoder=None, json_schema_extensions=None))]
     fn new(
         item_types: &Bound<'_, PyAny>,
         dump_discriminator: &Bound<'_, PyAny>,
         load_discriminator: &Bound<'_, PyAny>,
         ref_name: String,
         custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
     ) -> PyClassInitializer<Self> {
-        ContainerBaseType::new(&ref_name, custom_encoder).add_subclass(DiscriminatedUnionType {
-            item_types: item_types.clone().unbind(),
-            dump_discriminator: dump_discriminator.clone().unbind(),
-            load_discriminator: load_discriminator.clone().unbind(),
-        })
+        ContainerBaseType::new(&ref_name, custom_encoder, json_schema_extensions).add_subclass(
+            DiscriminatedUnionType {
+                item_types: item_types.clone().unbind(),
+                dump_discriminator: dump_discriminator.clone().unbind(),
+                load_discriminator: load_discriminator.clone().unbind(),
+            },
+        )
     }
 
     fn __eq__(self_: PyRef<'_, Self>, other: PyRef<'_, Self>, py: Python<'_>) -> PyResult<bool> {
@@ -1113,16 +1181,19 @@ pub struct UnionType {
 #[pymethods]
 impl UnionType {
     #[new]
-    #[pyo3(signature = (item_types, ref_name, custom_encoder=None))]
+    #[pyo3(signature = (item_types, ref_name, custom_encoder=None, json_schema_extensions=None))]
     fn new(
         item_types: &Bound<'_, PyAny>,
         ref_name: String,
         custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
     ) -> PyClassInitializer<Self> {
-        ContainerBaseType::new(&ref_name, custom_encoder).add_subclass(UnionType {
-            item_types: item_types.clone().unbind(),
-            repr: ref_name,
-        })
+        ContainerBaseType::new(&ref_name, custom_encoder, json_schema_extensions).add_subclass(
+            UnionType {
+                item_types: item_types.clone().unbind(),
+                repr: ref_name,
+            },
+        )
     }
 
     fn __eq__(self_: PyRef<'_, Self>, other: PyRef<'_, Self>, py: Python<'_>) -> PyResult<bool> {
@@ -1151,10 +1222,11 @@ pub struct LiteralType {
 #[pymethods]
 impl LiteralType {
     #[new]
-    #[pyo3(signature = (args, custom_encoder=None))]
+    #[pyo3(signature = (args, custom_encoder=None, json_schema_extensions=None))]
     fn new(
         args: &Bound<'_, PyList>,
         custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<PyClassInitializer<Self>> {
         let len = args.len();
         let load_map = PyDict::new(args.py());
@@ -1180,12 +1252,14 @@ impl LiteralType {
             }
         }
 
-        Ok(BaseType::new(custom_encoder).add_subclass(LiteralType {
-            args: args.clone().unbind(),
-            items_repr: format!("[{}]", items_repr.join(", ")),
-            load_map: load_map.unbind(),
-            dump_map: dump_map.unbind(),
-        }))
+        Ok(
+            BaseType::new(custom_encoder, json_schema_extensions).add_subclass(LiteralType {
+                args: args.clone().unbind(),
+                items_repr: format!("[{}]", items_repr.join(", ")),
+                load_map: load_map.unbind(),
+                dump_map: dump_map.unbind(),
+            }),
+        )
     }
 
     fn __eq__(self_: PyRef<'_, Self>, other: PyRef<'_, Self>, py: Python<'_>) -> PyResult<bool> {
@@ -1211,14 +1285,15 @@ pub struct RecursionHolder {
 #[pymethods]
 impl RecursionHolder {
     #[new]
-    #[pyo3(signature = (name, state_key, meta, custom_encoder=None))]
+    #[pyo3(signature = (name, state_key, meta, custom_encoder=None, json_schema_extensions=None))]
     fn new(
         name: &Bound<'_, PyAny>,
         state_key: &Bound<'_, PyAny>,
         meta: &Bound<'_, PyAny>,
         custom_encoder: Option<&Bound<'_, PyAny>>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
     ) -> PyClassInitializer<Self> {
-        BaseType::new(custom_encoder).add_subclass(RecursionHolder {
+        BaseType::new(custom_encoder, json_schema_extensions).add_subclass(RecursionHolder {
             name: name.clone().unbind(),
             state_key: state_key.clone().unbind(),
             meta: meta.clone().unbind(),
@@ -1262,11 +1337,13 @@ pub struct CustomType {
 #[pymethods]
 impl CustomType {
     #[new]
+    #[pyo3(signature = (custom_encoder, json_schema, json_schema_extensions=None))]
     fn new(
         custom_encoder: &Bound<'_, PyAny>,
         json_schema: &Bound<'_, PyAny>,
+        json_schema_extensions: Option<&Bound<'_, PyDict>>,
     ) -> PyClassInitializer<Self> {
-        BaseType::new(Some(custom_encoder)).add_subclass(CustomType {
+        BaseType::new(Some(custom_encoder), json_schema_extensions).add_subclass(CustomType {
             json_schema: json_schema.clone().unbind(),
         })
     }

--- a/tests/json_schema/test_json_schema_extension.py
+++ b/tests/json_schema/test_json_schema_extension.py
@@ -1,0 +1,82 @@
+from dataclasses import dataclass
+from typing import Annotated, Optional
+
+import pytest
+from serpyco_rs import Serializer
+from serpyco_rs.metadata import JsonSchemaExtension, Max, Min
+
+
+@pytest.fixture
+def ns(request) -> str:
+    return f'tests.json_schema.test_json_schema_extension.{request.node.name}'
+
+
+def test_extension_on_simple_type():
+    serializer = Serializer(Annotated[str, JsonSchemaExtension({'x-custom': 'value'})])
+    schema = serializer.get_json_schema()
+    assert schema['x-custom'] == 'value'
+    assert schema['type'] == 'string'
+
+
+def test_extension_on_dataclass_field(ns):
+    @dataclass
+    class User:
+        email: Annotated[str, JsonSchemaExtension({'x-custom': 'tagged'})]
+        name: str
+
+    serializer = Serializer(User)
+    schema = serializer.get_json_schema()
+    user_schema = schema['components']['schemas'][f'{ns}.<locals>.User']
+    assert user_schema['properties']['email']['x-custom'] == 'tagged'
+    assert 'x-custom' not in user_schema['properties']['name']
+
+
+def test_extension_combined_with_other_metadata():
+    serializer = Serializer(Annotated[int, Min(0), Max(100), JsonSchemaExtension({'x-audit': True})])
+    schema = serializer.get_json_schema()
+    assert schema['minimum'] == 0
+    assert schema['maximum'] == 100
+    assert schema['x-audit'] is True
+
+
+def test_multiple_extensions_merged():
+    serializer = Serializer(Annotated[str, JsonSchemaExtension({'x-a': 1}), JsonSchemaExtension({'x-b': 2})])
+    schema = serializer.get_json_schema()
+    assert schema['x-a'] == 1
+    assert schema['x-b'] == 2
+
+
+def test_extension_on_optional_field(ns):
+    @dataclass
+    class Data:
+        value: Annotated[Optional[str], JsonSchemaExtension({'x-tag': 'opt'})]
+
+    serializer = Serializer(Data)
+    schema = serializer.get_json_schema()
+    data_schema = schema['components']['schemas'][f'{ns}.<locals>.Data']
+    assert data_schema['properties']['value']['x-tag'] == 'opt'
+
+
+def test_serialization_unaffected():
+    @dataclass
+    class Data:
+        email: Annotated[str, JsonSchemaExtension({'x-custom': 'value'})]
+
+    serializer = Serializer(Data)
+    obj = Data(email='test@example.com')
+    dumped = serializer.dump(obj)
+    assert dumped == {'email': 'test@example.com'}
+    assert serializer.load(dumped) == obj
+
+
+def test_conflicting_extension_keys_last_wins():
+    serializer = Serializer(Annotated[str, JsonSchemaExtension({'x-a': 1}), JsonSchemaExtension({'x-a': 2})])
+    schema = serializer.get_json_schema()
+    assert schema['x-a'] == 2
+
+
+def test_extension_on_list():
+    serializer = Serializer(Annotated[list[int], JsonSchemaExtension({'x-items': 'ids'})])
+    schema = serializer.get_json_schema()
+    assert schema['type'] == 'array'
+    assert schema['x-items'] == 'ids'


### PR DESCRIPTION
## Summary

- Add `JsonSchemaExtension` metadata class that allows attaching arbitrary JSON Schema extension fields to any type via `Annotated`
- Multiple `JsonSchemaExtension` on the same type are merged automatically (later overrides earlier for same key)
- Extensions are propagated through type info (`BaseType.json_schema_extensions`) and applied in JSON Schema generation

## Usage

```python
from serpyco_rs import Serializer
from serpyco_rs.metadata import JsonSchemaExtension

@dataclass
class User:
    email: Annotated[str, JsonSchemaExtension({"x-custom": "value"})]

ser = Serializer(User)
# ser.get_json_schema() → email property includes "x-custom": "value"
```

## Test plan

- [x] Extension on simple types (str, int, list)
- [x] Extension on dataclass fields
- [x] Combined with other metadata (Min/Max)
- [x] Multiple extensions merged
- [x] Optional field with extension
- [x] Serialization/deserialization unaffected
- [x] Conflicting keys — last wins
- [x] Full existing test suite passes (374 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)