### PR TITLE
[codex] Drop Python 3.9 support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,6 @@ jobs:
           - windows-latest
           - macos-latest
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
@@ -137,7 +136,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           manylinux: auto
           docker-options: ${{ matrix.platform.maturin_docker_options }}
-          args: --release --sdist -o dist --interpreter 3.9 3.10 3.11 3.12 3.13 3.14
+          args: --release --sdist -o dist --interpreter 3.10 3.11 3.12 3.13 3.14
           sccache: "true"
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -151,7 +150,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     name: Test on ${{ matrix.os}} ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ versions](https://img.shields.io/pypi/pyversions/serpyco-rs.svg)](https://pypi.o
 ## What is serpyco-rs ?
 
 
-Serpyco is a serialization library for [Python 3.9+ dataclasses](https://docs.python.org/3/library/dataclasses.html) that works just by defining your dataclasses:
+Serpyco is a serialization library for [Python 3.10+ dataclasses](https://docs.python.org/3/library/dataclasses.html) that works just by defining your dataclasses:
 
 ```python
 import dataclasses

--- a/bench/compare/github_issue/_utils.py
+++ b/bench/compare/github_issue/_utils.py
@@ -1,9 +1,0 @@
-import sys
-from typing import Any
-
-
-def get_dataclass_args() -> dict[str, Any]:
-    # python 3.9 does not support dataclasses(slot=True)
-    if sys.version_info < (3, 10):
-        return {}
-    return {'slots': True}

--- a/bench/compare/github_issue/mashumaro.py
+++ b/bench/compare/github_issue/mashumaro.py
@@ -6,8 +6,6 @@ from typing import Any, Optional, Union
 from mashumaro import DataClassDictMixin, field_options, pass_through
 from mashumaro.config import BaseConfig
 
-from ._utils import get_dataclass_args
-
 
 class BaseModel(DataClassDictMixin):
     class Config(BaseConfig):
@@ -46,7 +44,7 @@ class AuthorAssociation(Enum):
     OWNER = 'OWNER'
 
 
-@dataclass(**get_dataclass_args())
+@dataclass(slots=True)
 class User(BaseModel):
     login: str
     id: int
@@ -71,7 +69,7 @@ class User(BaseModel):
     starred_at: Optional[datetime] = None
 
 
-@dataclass(**get_dataclass_args())
+@dataclass(slots=True)
 class IssueLabel(BaseModel):
     id: int
     node_id: str
@@ -82,7 +80,7 @@ class IssueLabel(BaseModel):
     default: bool
 
 
-@dataclass(**get_dataclass_args())
+@dataclass(slots=True)
 class Milestone(BaseModel):
     url: str
     html_url: str
@@ -102,7 +100,7 @@ class Milestone(BaseModel):
     state: MilestoneState = MilestoneState.OPEN
 
 
-@dataclass(**get_dataclass_args())
+@dataclass(slots=True)
 class Reactions(BaseModel):
     url: str
     total_count: int
@@ -116,7 +114,7 @@ class Reactions(BaseModel):
     rocket: int
 
 
-@dataclass(**get_dataclass_args())
+@dataclass(slots=True)
 class Issue(BaseModel):
     id: int
     node_id: str

--- a/bench/compare/github_issue/serpyco_rs.py
+++ b/bench/compare/github_issue/serpyco_rs.py
@@ -6,8 +6,6 @@ from typing import Annotated, Any, Optional, Union
 import serpyco_rs
 from serpyco_rs.metadata import Alias
 
-from ._utils import get_dataclass_args
-
 
 class IssueState(Enum):
     OPEN = 'open'
@@ -36,7 +34,7 @@ class AuthorAssociation(Enum):
     OWNER = 'OWNER'
 
 
-@dataclass(**get_dataclass_args())
+@dataclass(slots=True)
 class User:
     login: str
     id: int
@@ -61,7 +59,7 @@ class User:
     starred_at: Optional[datetime] = None
 
 
-@dataclass(**get_dataclass_args())
+@dataclass(slots=True)
 class IssueLabel:
     id: int
     node_id: str
@@ -72,7 +70,7 @@ class IssueLabel:
     default: bool
 
 
-@dataclass(**get_dataclass_args())
+@dataclass(slots=True)
 class Milestone:
     url: str
     html_url: str
@@ -92,7 +90,7 @@ class Milestone:
     state: MilestoneState = MilestoneState.OPEN
 
 
-@dataclass(**get_dataclass_args())
+@dataclass(slots=True)
 class Reactions:
     url: str
     total_count: int
@@ -106,7 +104,7 @@ class Reactions:
     rocket: int
 
 
-@dataclass(**get_dataclass_args())
+@dataclass(slots=True)
 class Issue:
     id: int
     node_id: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ module-name = "serpyco_rs._serpyco_rs"
 name = "serpyco-rs"
 dynamic = ["version"]
 repository = "https://github.com/ermakov-oleg/serpyco-rs"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { file = "LICENSE" }
 classifiers = [
     "License :: OSI Approved :: MIT License",
@@ -18,7 +18,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/python/serpyco_rs/_describe.py
+++ b/python/serpyco_rs/_describe.py
@@ -10,10 +10,10 @@ from typing import (
     ForwardRef,
     Generic,
     Literal,
-    Optional,
+    TypeGuard,
     TypeVar,
-    Union,
     cast,
+    get_args,
     get_origin,
     overload,
 )
@@ -21,10 +21,8 @@ from uuid import UUID
 
 from typing_extensions import (
     Never,
-    TypeGuard,
     assert_never,
     evaluate_forward_ref,
-    get_args,
     is_typeddict,
 )
 
@@ -104,12 +102,12 @@ _T = TypeVar('_T')
 class _TypeResolver:
     resolver_context: _Stack[ResolverContext]
     annotations: _MergeStack[Annotations]
-    custom_type_resolver: Optional[Callable[[Any], Optional[CustomTypeMeta[Any, Any]]]]
+    custom_type_resolver: Callable[[Any], CustomTypeMeta[Any, Any] | None] | None
 
     def __init__(
         self,
         globals: dict[str, Any],
-        custom_type_resolver: Optional[Callable[[Any], Optional[CustomTypeMeta[Any, Any]]]] = None,
+        custom_type_resolver: Callable[[Any], CustomTypeMeta[Any, Any] | None] | None = None,
     ):
         self.resolver_context = _Stack(ResolverContext(globals=globals))
         self.custom_type_resolver = custom_type_resolver
@@ -291,7 +289,7 @@ class _TypeResolver:
 
         raise RuntimeError(f'Unknown type {t!r}')
 
-    def _match_simple_types(self, t: Any) -> Optional[BaseType]:
+    def _match_simple_types(self, t: Any) -> BaseType | None:
         if not isinstance(t, type):
             return None
 
@@ -313,7 +311,7 @@ class _TypeResolver:
         if simple := simple_type_mapping.get(t):
             return simple(custom_encoder=custom_encoder, json_schema_extensions=json_schema_extensions)
 
-        number_type_mapping: Mapping[type, type[Union[IntegerType, FloatType]]] = {
+        number_type_mapping: Mapping[type, type[IntegerType | FloatType]] = {
             int: IntegerType,
             float: FloatType,
         }
@@ -389,7 +387,7 @@ class _TypeResolver:
             )
 
         for struct_field in struct_flatten_fields:
-            struct_type = cast(Union[EntityType, TypedDictType], struct_field.field_type)
+            struct_type = cast(EntityType | TypedDictType, struct_field.field_type)
             for nested_field in struct_type.fields:
                 if nested_field.dict_key in regular_field_keys:
                     raise RuntimeError(
@@ -419,8 +417,8 @@ class _TypeResolver:
         self,
         t: Any,
         name: str,
-        custom_encoder: Optional[CustomEncoder[Any, Any]],
-    ) -> Union[EntityType, TypedDictType]:
+        custom_encoder: CustomEncoder[Any, Any] | None,
+    ) -> EntityType | TypedDictType:
         # PEP-484: Replace all unfilled type parameters with Any
         if get_origin(t) is None and getattr(t, '__parameters__', None):
             t = t[(Any,) * len(t.__parameters__)]
@@ -522,8 +520,8 @@ class _TypeResolver:
 
 def describe_type(
     t: Any,
-    meta: Optional[ResolverContext] = None,
-    custom_type_resolver: Optional[Callable[[Any], Optional[CustomTypeMeta[Any, Any]]]] = None,
+    meta: ResolverContext | None = None,
+    custom_type_resolver: Callable[[Any], CustomTypeMeta[Any, Any] | None] | None = None,
 ) -> BaseType:
     return _TypeResolver(_get_globals(t), custom_type_resolver).resolve(t)
 
@@ -531,9 +529,9 @@ def describe_type(
 @dataclasses.dataclass
 class _Field(Generic[_T]):
     name: str
-    type: Union[type[_T], str, Any]
-    default: Union[DefaultValue[_T], DefaultValue[None]] = NOT_SET
-    default_factory: Union[DefaultValue[Callable[[], _T]], DefaultValue[None]] = NOT_SET
+    type: type[_T] | str | Any
+    default: DefaultValue[_T] | DefaultValue[None] = NOT_SET
+    default_factory: DefaultValue[Callable[[], _T]] | DefaultValue[None] = NOT_SET
 
 
 def _get_entity_fields(t: Any) -> Sequence[_Field[Any]]:
@@ -589,14 +587,14 @@ def _find_metadata(annotations: Iterable[Any], type_: type[_T], default: _T) -> 
 
 
 @overload
-def _find_metadata(annotations: Iterable[Any], type_: type[_T], default: None = None) -> Optional[_T]: ...
+def _find_metadata(annotations: Iterable[Any], type_: type[_T], default: None = None) -> _T | None: ...
 
 
-def _find_metadata(annotations: Iterable[Any], type_: type[_T], default: Optional[_T] = None) -> Optional[_T]:
+def _find_metadata(annotations: Iterable[Any], type_: type[_T], default: _T | None = None) -> _T | None:
     return next((ann for ann in annotations if isinstance(ann, type_)), default)
 
 
-def _apply_format(f: Optional[FieldFormat], value: str) -> str:
+def _apply_format(f: FieldFormat | None, value: str) -> str:
     if not f or f.format is Format.no_format:
         return value
     if f.format is Format.camel_case:
@@ -684,7 +682,7 @@ def _is_required_in_typeddict(t: Any, key: str) -> bool:
     raise RuntimeError(f'Expected TypedDict, got "{t!r}"')
 
 
-def _get_dataclass_doc(cls: Any) -> Optional[str]:
+def _get_dataclass_doc(cls: Any) -> str | None:
     """Dataclass has automatically generated docstring, which is not very useful."""
     doc: str = cls.__doc__
     if doc is None or doc.startswith(f'{cls.__name__}('):
@@ -702,7 +700,7 @@ def _is_frozen_dataclass(cls: Any, field: EntityField) -> bool:
         return False
 
 
-def _is_supported_literal_args(args: Sequence[Any]) -> TypeGuard[list[Union[str, int, Enum]]]:
+def _is_supported_literal_args(args: Sequence[Any]) -> TypeGuard[list[str | int | Enum]]:
     return all(isinstance(arg, (str, int, Enum)) for arg in args)
 
 

--- a/python/serpyco_rs/_impl.pyi
+++ b/python/serpyco_rs/_impl.pyi
@@ -1,6 +1,6 @@
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from enum import Enum, IntEnum
-from typing import Any, Callable, Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 from ._meta import ResolverContext
 

--- a/python/serpyco_rs/_json_schema/_convert.py
+++ b/python/serpyco_rs/_json_schema/_convert.py
@@ -1,19 +1,11 @@
-import sys
 import typing
 from enum import Enum
 from functools import singledispatch
-from typing import Any, Optional, Union
-
-from .._utils import get_attributes_doc
-from ._consts import DEFAULT_REF_PREFIX, SCHEMA_VERSION
-
-
-if sys.version_info >= (3, 10):
-    from typing import TypeGuard
-else:
-    from typing_extensions import TypeGuard
+from typing import Any, TypeGuard
 
 from .. import _describe as describe
+from .._utils import get_attributes_doc
+from ._consts import DEFAULT_REF_PREFIX, SCHEMA_VERSION
 from ._entities import (
     ArrayType,
     Boolean,
@@ -65,12 +57,12 @@ def get_json_schema(t: describe.BaseType) -> dict[str, Any]:
 
 
 @singledispatch
-def to_json_schema(_: Any, doc: Optional[str] = None, *, config: Config) -> Schema:
+def to_json_schema(_: Any, doc: str | None = None, *, config: Config) -> Schema:
     return Schema(description=doc, config=config)
 
 
 @to_json_schema.register
-def _(arg: describe.StringType, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(arg: describe.StringType, doc: str | None = None, *, config: Config) -> Schema:
     return StringType(
         minLength=arg.min_length,
         maxLength=arg.max_length,
@@ -81,12 +73,12 @@ def _(arg: describe.StringType, doc: Optional[str] = None, *, config: Config) ->
 
 
 @to_json_schema.register
-def _(arg: describe.NoneType, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(arg: describe.NoneType, doc: str | None = None, *, config: Config) -> Schema:
     return Null(config=config, json_schema_extensions=arg.json_schema_extensions)
 
 
 @to_json_schema.register
-def _(arg: describe.NeverType, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(arg: describe.NeverType, doc: str | None = None, *, config: Config) -> Schema:
     # Never type in JSON Schema is represented as a schema that matches nothing
     return Schema(
         additionalArgs={'not': {}},
@@ -97,7 +89,7 @@ def _(arg: describe.NeverType, doc: Optional[str] = None, *, config: Config) -> 
 
 
 @to_json_schema.register
-def _(arg: describe.IntegerType, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(arg: describe.IntegerType, doc: str | None = None, *, config: Config) -> Schema:
     return IntegerType(
         minimum=arg.min if arg.inclusive_min else None,
         maximum=arg.max if arg.inclusive_max else None,
@@ -110,7 +102,7 @@ def _(arg: describe.IntegerType, doc: Optional[str] = None, *, config: Config) -
 
 
 @to_json_schema.register
-def _(arg: describe.BytesType, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(arg: describe.BytesType, doc: str | None = None, *, config: Config) -> Schema:
     return StringType(
         format='binary',
         description=doc,
@@ -120,7 +112,7 @@ def _(arg: describe.BytesType, doc: Optional[str] = None, *, config: Config) -> 
 
 
 @to_json_schema.register
-def _(arg: describe.FloatType, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(arg: describe.FloatType, doc: str | None = None, *, config: Config) -> Schema:
     return NumberType(
         minimum=arg.min if arg.inclusive_min else None,
         maximum=arg.max if arg.inclusive_max else None,
@@ -133,7 +125,7 @@ def _(arg: describe.FloatType, doc: Optional[str] = None, *, config: Config) -> 
 
 
 @to_json_schema.register
-def _(arg: describe.DecimalType, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(arg: describe.DecimalType, doc: str | None = None, *, config: Config) -> Schema:
     # todo: support min/max
     return Schema(
         oneOf=[
@@ -147,34 +139,34 @@ def _(arg: describe.DecimalType, doc: Optional[str] = None, *, config: Config) -
 
 
 @to_json_schema.register
-def _(arg: describe.BooleanType, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(arg: describe.BooleanType, doc: str | None = None, *, config: Config) -> Schema:
     return Boolean(config=config, description=doc, json_schema_extensions=arg.json_schema_extensions)
 
 
 @to_json_schema.register
-def _(arg: describe.UUIDType, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(arg: describe.UUIDType, doc: str | None = None, *, config: Config) -> Schema:
     return StringType(format='uuid', description=doc, config=config, json_schema_extensions=arg.json_schema_extensions)
 
 
 @to_json_schema.register
-def _(arg: describe.TimeType, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(arg: describe.TimeType, doc: str | None = None, *, config: Config) -> Schema:
     return StringType(format='time', description=doc, config=config, json_schema_extensions=arg.json_schema_extensions)
 
 
 @to_json_schema.register
-def _(arg: describe.DateTimeType, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(arg: describe.DateTimeType, doc: str | None = None, *, config: Config) -> Schema:
     return StringType(
         format='date-time', description=doc, config=config, json_schema_extensions=arg.json_schema_extensions
     )
 
 
 @to_json_schema.register
-def _(arg: describe.DateType, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(arg: describe.DateType, doc: str | None = None, *, config: Config) -> Schema:
     return StringType(format='date', description=doc, config=config, json_schema_extensions=arg.json_schema_extensions)
 
 
 @to_json_schema.register
-def _(arg: describe.EnumType, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(arg: describe.EnumType, doc: str | None = None, *, config: Config) -> Schema:
     docs = get_attributes_doc(arg.cls)
     enum_values = [item.value for item in arg.items]
     type_ = None
@@ -192,7 +184,7 @@ def _(arg: describe.EnumType, doc: Optional[str] = None, *, config: Config) -> S
 
 
 @to_json_schema.register
-def _(arg: describe.OptionalType, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(arg: describe.OptionalType, doc: str | None = None, *, config: Config) -> Schema:
     return Schema(
         anyOf=[
             Null(config=config),
@@ -205,7 +197,7 @@ def _(arg: describe.OptionalType, doc: Optional[str] = None, *, config: Config) 
 
 
 @to_json_schema.register
-def _(arg: describe.EntityType, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(arg: describe.EntityType, doc: str | None = None, *, config: Config) -> Schema:
     properties: dict[str, Schema] = {}
     required: list[str] = []
     dict_flatten_additional_properties: bool | Schema | None = None
@@ -240,7 +232,7 @@ def _(arg: describe.EntityType, doc: Optional[str] = None, *, config: Config) ->
 
 
 @to_json_schema.register
-def _(arg: describe.TypedDictType, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(arg: describe.TypedDictType, doc: str | None = None, *, config: Config) -> Schema:
     return ObjectType(
         properties={prop.dict_key: to_json_schema(prop.field_type, prop.doc, config=config) for prop in arg.fields},
         required=[prop.dict_key for prop in arg.fields if prop.required] or None,
@@ -252,7 +244,7 @@ def _(arg: describe.TypedDictType, doc: Optional[str] = None, *, config: Config)
 
 
 @to_json_schema.register
-def _(arg: describe.ArrayType, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(arg: describe.ArrayType, doc: str | None = None, *, config: Config) -> Schema:
     schema = ArrayType(
         items=to_json_schema(arg.item_type, config=config),
         minItems=arg.min_length,
@@ -268,7 +260,7 @@ def _(arg: describe.ArrayType, doc: Optional[str] = None, *, config: Config) -> 
 
 
 @to_json_schema.register
-def _(arg: describe.DictionaryType, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(arg: describe.DictionaryType, doc: str | None = None, *, config: Config) -> Schema:
     return ObjectType(
         additionalProperties=to_json_schema(arg.value_type, config=config),
         description=doc,
@@ -278,7 +270,7 @@ def _(arg: describe.DictionaryType, doc: Optional[str] = None, *, config: Config
 
 
 @to_json_schema.register
-def _(arg: describe.TupleType, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(arg: describe.TupleType, doc: str | None = None, *, config: Config) -> Schema:
     schema = ArrayType(
         prefixItems=[to_json_schema(item, config=config) for item in arg.item_types],
         minItems=len(arg.item_types),
@@ -293,19 +285,19 @@ def _(arg: describe.TupleType, doc: Optional[str] = None, *, config: Config) -> 
 
 
 @to_json_schema.register
-def _(arg: describe.AnyType, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(arg: describe.AnyType, doc: str | None = None, *, config: Config) -> Schema:
     return Schema(description=doc, config=config, json_schema_extensions=arg.json_schema_extensions)
 
 
 @to_json_schema.register
-def _(holder: describe.RecursionHolder, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(holder: describe.RecursionHolder, doc: str | None = None, *, config: Config) -> Schema:
     return RefType(
         description=doc, name=holder.name, config=config, json_schema_extensions=holder.json_schema_extensions
     )
 
 
 @to_json_schema.register
-def _(arg: describe.LiteralType, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(arg: describe.LiteralType, doc: str | None = None, *, config: Config) -> Schema:
     return Schema(
         enum=[arg.value if isinstance(arg, Enum) else arg for arg in arg.args],
         description=doc,
@@ -315,7 +307,7 @@ def _(arg: describe.LiteralType, doc: Optional[str] = None, *, config: Config) -
 
 
 @to_json_schema.register
-def _(arg: describe.UnionType, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(arg: describe.UnionType, doc: str | None = None, *, config: Config) -> Schema:
     schema = Schema(
         anyOf=[to_json_schema(t, config=config) for t in arg.item_types],
         description=doc,
@@ -330,7 +322,7 @@ def _(arg: describe.UnionType, doc: Optional[str] = None, *, config: Config) -> 
 
 
 @to_json_schema.register
-def _(arg: describe.DiscriminatedUnionType, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(arg: describe.DiscriminatedUnionType, doc: str | None = None, *, config: Config) -> Schema:
     objects = {
         name: schema
         for name, t in arg.item_types.items()
@@ -353,14 +345,14 @@ def _(arg: describe.DiscriminatedUnionType, doc: Optional[str] = None, *, config
     return schema
 
 
-def _check_unions_schema_types(schema: Schema) -> TypeGuard[Union[ObjectType, RefType]]:
+def _check_unions_schema_types(schema: Schema) -> TypeGuard[ObjectType | RefType]:
     if isinstance(schema, (ObjectType, RefType)):
         return True
     raise RuntimeError(f'Unions schema items must be ObjectType or RefType. Current: {schema}')
 
 
 @to_json_schema.register
-def _(arg: describe.CustomType, doc: Optional[str] = None, *, config: Config) -> Schema:
+def _(arg: describe.CustomType, doc: str | None = None, *, config: Config) -> Schema:
     return Schema(
         additionalArgs=arg.json_schema,
         description=doc,

--- a/python/serpyco_rs/_main.py
+++ b/python/serpyco_rs/_main.py
@@ -1,6 +1,6 @@
 import abc
 from collections.abc import Callable
-from typing import Annotated, Any, Generic, Optional, Protocol, TypeVar, Union, cast, overload
+from typing import Annotated, Any, Generic, Protocol, TypeVar, cast, overload
 
 from ._custom_types import CustomType
 from ._describe import BaseType, describe_type
@@ -24,9 +24,9 @@ class _MultiMapping(Protocol[_T, _D]):
     def getall(self, key: str) -> list[_T]: ...
     @overload
     @abc.abstractmethod
-    def getall(self, key: str, default: _D) -> Union[list[_T], _D]: ...
+    def getall(self, key: str, default: _D) -> list[_T] | _D: ...
     @abc.abstractmethod
-    def getall(self, key: str, default: _D = ...) -> Union[list[_T], _D]: ...
+    def getall(self, key: str, default: _D = ...) -> list[_T] | _D: ...
 
 
 class Serializer(Generic[_T]):
@@ -40,7 +40,7 @@ class Serializer(Generic[_T]):
         omit_none: bool = False,
         force_default_for_optional: bool = False,
         naive_datetime_to_utc: bool = False,
-        custom_type_resolver: Optional[Callable[[Any], Optional[CustomType[Any, Any]]]] = None,
+        custom_type_resolver: Callable[[Any], CustomType[Any, Any] | None] | None = None,
     ) -> None:
         """
         Create a serializer for the given type.

--- a/python/serpyco_rs/_meta.py
+++ b/python/serpyco_rs/_meta.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from dataclasses import dataclass, field
 from functools import cached_property
-from typing import Any, Optional, TypeVar, overload
+from typing import Any, TypeVar, overload
 
 from typing_extensions import Self
 
@@ -14,18 +14,18 @@ class ResolverContext:
     """Context for the type resolution process"""
 
     globals: dict[str, Any]
-    type_cache: dict[str, Optional[BaseType]] = field(default_factory=dict)
+    type_cache: dict[str, BaseType | None] = field(default_factory=dict)
     usage_count: defaultdict[str, int] = field(default_factory=lambda: defaultdict[str, int](int))
-    discriminator_field: Optional[str] = None
+    discriminator_field: str | None = None
 
-    def cache_type(self, key: str, value: Optional[BaseType]) -> None:
+    def cache_type(self, key: str, value: BaseType | None) -> None:
         """Cache a resolved type"""
         self.type_cache[key] = value
 
-    def __getitem__(self, item: str) -> Optional[BaseType]:
+    def __getitem__(self, item: str) -> BaseType | None:
         return self.type_cache.get(item)
 
-    def get_cached_type(self, key: str) -> Optional[BaseType]:
+    def get_cached_type(self, key: str) -> BaseType | None:
         """Get a cached type by key"""
         return self.type_cache.get(key)
 
@@ -55,12 +55,12 @@ class Annotations:
             self._data[type(arg)] = arg
 
     @overload
-    def get(self, key: type[_T], default: None = None) -> Optional[_T]: ...
+    def get(self, key: type[_T], default: None = None) -> _T | None: ...
 
     @overload
     def get(self, key: type[_T], default: _T) -> _T: ...
 
-    def get(self, key: type[_T], default: Optional[_T] = None) -> Optional[_T]:
+    def get(self, key: type[_T], default: _T | None = None) -> _T | None:
         return self._data.get(key, default)
 
     def merge(self, other: Self) -> Self:

--- a/python/serpyco_rs/_secial_forms.py
+++ b/python/serpyco_rs/_secial_forms.py
@@ -2,9 +2,9 @@ import sys
 import types
 import typing
 from contextlib import suppress
-from typing import Annotated, Any, ClassVar, Final, ForwardRef, Union, get_origin
+from typing import Annotated, Any, ClassVar, Final, ForwardRef, Union, get_args, get_origin
 
-from typing_extensions import NotRequired, ReadOnly, Required, get_args
+from typing_extensions import NotRequired, ReadOnly, Required
 
 from ._meta import Annotations
 from .metadata import JsonSchemaExtension
@@ -120,10 +120,7 @@ def is_readonly(origin: Any) -> bool:
 def is_union_type(origin: Any) -> bool:
     if origin is Union:
         return True
-    # Python 3.10+ union syntax (X | Y)
-    if sys.version_info >= (3, 10) and origin is types.UnionType:
-        return True
-    return False
+    return origin is types.UnionType
 
 
 def is_literal_type(annotation: Any) -> bool:

--- a/python/serpyco_rs/_type_utils.py
+++ b/python/serpyco_rs/_type_utils.py
@@ -12,7 +12,6 @@ from typing import (
     ForwardRef,
     Generic,
     TypeVar,
-    Union,
     _AnnotatedAlias,
     _eval_type,
     _GenericAlias,
@@ -45,8 +44,8 @@ _allowed_types = (
 
 def get_type_hints(
     obj: Any,
-    globalns: Union[dict[str, Any], None] = None,
-    localns: Union[dict[str, Any], None] = None,
+    globalns: dict[str, Any] | None = None,
+    localns: dict[str, Any] | None = None,
     include_extras: bool = False,
 ) -> dict[str, Any]:
     """Return type hints for an object.
@@ -584,7 +583,7 @@ def _strip_annotations(t):
     return t
 
 
-# python 3.9 / 3.10 compatibility
+# Python 3.10 compatibility
 
 
 def _typevar_subst(arg):

--- a/python/serpyco_rs/_utils.py
+++ b/python/serpyco_rs/_utils.py
@@ -2,7 +2,7 @@ import re
 from collections.abc import Iterator
 from contextlib import contextmanager
 from functools import lru_cache
-from typing import Generic, Optional, Protocol, TypeVar
+from typing import Generic, Protocol, TypeVar
 
 from attributes_doc import get_attributes_doc as _get_attributes_doc
 from typing_extensions import Self
@@ -22,7 +22,7 @@ _T = TypeVar('_T')
 
 
 class _Stack(Generic[_T]):
-    def __init__(self, init: Optional[_T] = None) -> None:
+    def __init__(self, init: _T | None = None) -> None:
         self._stack = [init] if init is not None else []
 
     @contextmanager

--- a/python/serpyco_rs/metadata.py
+++ b/python/serpyco_rs/metadata.py
@@ -1,20 +1,20 @@
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, TypeVar, Union
+from typing import Any, TypeVar
 
 from ._impl import CustomEncoder
 
 
 @dataclass(frozen=True)
 class Min:
-    value: Union[int, float]
+    value: int | float
     inclusive: bool = True
 
 
 @dataclass(frozen=True)
 class Max:
-    value: Union[int, float]
+    value: int | float
     inclusive: bool = True
 
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,7 +1,7 @@
 line-length = 120
 src = ["python/serpyco_rs", "tests"]
 exclude = ["pyproject.toml"]
-target-version = "py39"
+target-version = "py310"
 
 [lint]
 select = [

--- a/tests/json_schema/test_convert.py
+++ b/tests/json_schema/test_convert.py
@@ -1,4 +1,3 @@
-import sys
 from dataclasses import dataclass
 from datetime import datetime, time
 from decimal import Decimal
@@ -177,7 +176,6 @@ def test_to_json_schema(ns):
     }
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason='New style unions available after 3.10')
 def test_to_json_schema__new_union_syntax():
     @dataclass
     class Data:

--- a/tests/json_schema/test_validator.py
+++ b/tests/json_schema/test_validator.py
@@ -1,4 +1,3 @@
-import sys
 import textwrap
 import uuid
 from dataclasses import dataclass
@@ -99,18 +98,16 @@ def test_validate(cls, value):
     Serializer(cls).load(value)
 
 
-if sys.version_info >= (3, 10):
-
-    @pytest.mark.parametrize(
-        ['cls', 'value'],
-        (
-            (Optional[int], None),
-            (int | None, None),
-            (int | None, 2),
-        ),
-    )
-    def test_validate_new_union(cls, value):
-        Serializer(cls).load(value)
+@pytest.mark.parametrize(
+    ['cls', 'value'],
+    (
+        (Optional[int], None),
+        (int | None, None),
+        (int | None, 2),
+    ),
+)
+def test_validate_new_union(cls, value):
+    Serializer(cls).load(value)
 
 
 def _mk_e(m=mock.ANY, ip=mock.ANY) -> Callable[[ErrorItem], None]:

--- a/tests/test__describe.py
+++ b/tests/test__describe.py
@@ -1,4 +1,3 @@
-import sys
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import date, datetime, time
@@ -526,7 +525,6 @@ def test_describe__unions():
     )
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason='New style unions available after 3.10')
 def test_describe__new_style_union_type__wrapped():
     assert describe_type(int | None) == OptionalType(inner=IntegerType(custom_encoder=None), custom_encoder=None)
 

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -210,7 +210,6 @@ def test_literal():
     assert serializer.dump('foo') == 'foo'
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason='New style unions available after 3.10')
 def test_optional():
     @dataclass
     class T:

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,4 +1,3 @@
-import sys
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import Enum
@@ -211,28 +210,26 @@ def test_defaults():
     assert entity_serializer.load({}) == Entity(foo='123', bar=[1, 2, 3])
 
 
-if sys.version_info >= (3, 10):
+def test_union_optional__dump_load__ok():
+    # arrange
+    @dataclass
+    class UnionClass:
+        name: str | None
+        count: None | int
 
-    def test_union_optional__dump_load__ok():
-        # arrange
-        @dataclass
-        class UnionClass:
-            name: str | None
-            count: None | int
+    # act
+    serializer = Serializer(UnionClass)
 
-        # act
-        serializer = Serializer(UnionClass)
+    # assert
+    foo = UnionClass(name=None, count=None)
+    dict_foo = {'name': None, 'count': None}
+    assert serializer.dump(foo) == dict_foo
+    assert foo == serializer.load(dict_foo)
 
-        # assert
-        foo = UnionClass(name=None, count=None)
-        dict_foo = {'name': None, 'count': None}
-        assert serializer.dump(foo) == dict_foo
-        assert foo == serializer.load(dict_foo)
-
-        bar = UnionClass(name='try', count=5)
-        dict_bar = {'name': 'try', 'count': 5}
-        assert serializer.dump(bar) == dict_bar
-        assert bar == serializer.load(dict_bar)
+    bar = UnionClass(name='try', count=5)
+    dict_bar = {'name': 'try', 'count': 5}
+    assert serializer.dump(bar) == dict_bar
+    assert bar == serializer.load(dict_bar)
 
 
 def test_serializer_with_camelcase():


### PR DESCRIPTION
## Summary

Drop Python 3.9 support now that it has reached end of life.

- Raise package metadata and Ruff target to Python 3.10+
- Remove Python 3.9 from CI build/test matrices and cross-wheel interpreters
- Remove now-dead Python 3.9/3.10 compatibility branches and test guards
- Delete the benchmark dataclass helper and use @dataclass(slots=True) directly

## Validation

- ./.venv/bin/ruff format --check python/serpyco_rs tests bench
- ./.venv/bin/ruff check python/serpyco_rs
- ./.venv/bin/pytest -q tests
- ./.venv/bin/pytest -q bench/compare/test_github_issue.py