### PR TITLE
Inline bounds and length validators with cold slow path

### DIFF
--- a/src/validator/validators.rs
+++ b/src/validator/validators.rs
@@ -48,6 +48,7 @@ where
     Ok(())
 }
 
+#[inline(always)]
 pub fn _check_bounds<T>(
     val: T,
     min: Option<T>,
@@ -62,6 +63,21 @@ where
     if min.is_none() && max.is_none() {
         return Ok(());
     }
+    _check_bounds_slow(val, min, max, inclusive_min, inclusive_max, instance_path)
+}
+
+#[cold]
+fn _check_bounds_slow<T>(
+    val: T,
+    min: Option<T>,
+    max: Option<T>,
+    inclusive_min: bool,
+    inclusive_max: bool,
+    instance_path: &InstancePath,
+) -> PyResult<()>
+where
+    T: PartialOrd + Display + Copy,
+{
     check_lower_bound(val, min, inclusive_min, instance_path)?;
     check_upper_bound(val, max, inclusive_max, instance_path)?;
     Ok(())
@@ -114,6 +130,7 @@ pub fn check_max_length(
     Ok(())
 }
 
+#[inline(always)]
 pub fn check_length(
     val: &Bound<'_, PyString>,
     min: Option<usize>,
@@ -123,6 +140,16 @@ pub fn check_length(
     if min.is_none() && max.is_none() {
         return Ok(());
     }
+    check_length_slow(val, min, max, instance_path)
+}
+
+#[cold]
+fn check_length_slow(
+    val: &Bound<'_, PyString>,
+    min: Option<usize>,
+    max: Option<usize>,
+    instance_path: &InstancePath,
+) -> PyResult<()> {
     let len = val.len()?;
     check_min_length(val, len, min, instance_path)?;
     check_max_length(val, len, max, instance_path)?;


### PR DESCRIPTION
## Summary

The generic `_check_bounds` and `check_length` carry `Display`-formatted error paths whose body size kept the compiler from inlining them. As a result every `list[int]`/`list[str]` element paid for a real call into the validator, even when no bound was configured on the type.

This splits each into a tiny `#[inline(always)]` fast path that returns early when no bound is set, plus a `#[cold]` slow path with the existing logic. The fast path now inlines into `IntEncoder` / `FloatEncoder` / `StringEncoder` hot loops, and `_check_bounds` disappears from samply flamegraphs entirely.

## Measurements

Tight loop, release build (1000 iterations of `.load(data)` measured):

| scenario | before | after | delta |
|---|---|---|---|
| `list[int]` load (1000 ints) | 4750 ns | 3480 ns | **−27%** |
| `dict[str, int]` load (1000 entries) | 18023 ns | 16237 ns | **−10%** |
| `dataclass(int, str)` load | 96 ns | 88 ns | **−8%** |
| `Union[int, dataclass]` load | 311 ns | 296 ns | **−5%** |
| dump scenarios | unchanged | unchanged | — |

`dump` paths are unchanged because they do not call the bound/length validators.

All 411 existing tests pass and `cargo clippy --all-targets --all-features -- -D warnings` is clean.