### PR TITLE
Run CodSpeed in instrumentation and walltime modes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -272,6 +272,10 @@ jobs:
 
   benchmark-codespeed:
     needs: [build]
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [instrumentation, walltime]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -279,7 +283,7 @@ jobs:
         id: cache-uv
         with:
           path: ~/.cache/uv
-          key: ubuntu-latest-python-3.13-uv
+          key: ubuntu-latest-python-3.13-uv-${{ matrix.mode }}
       - name: set up Python 3.13
         uses: actions/setup-python@v4
         with:
@@ -300,6 +304,7 @@ jobs:
         uses: CodSpeedHQ/action@v3
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
+          mode: ${{ matrix.mode }}
           run: nox -s bench_codespeed --no-venv --no-install
         env:
           CI: true


### PR DESCRIPTION
## Summary

Until now CodSpeed only ran in **instrumentation** mode (cachegrind / retired instructions). That mode is reproducible and noise-free, but blind to classes of improvements that don't change instruction counts:

- PLT-stub overhead from cross-library FFI calls (e.g. calls into libpython)
- ICache / iTLB pressure
- Anything hidden inside libpython itself

A concrete example: replacing \`PyObject_SetAttr\` with a direct \`tp_setattro\` call (#233) skips \`PyUnicode_InternInPlace\` and yields a real **−9% wall-clock** on github_issue load, but CodSpeed instrumentation reports "untouched". The wins are real but invisible to the current setup.

## Change

Adds a parallel **walltime** job via a matrix:

\`\`\`yaml
strategy:
  fail-fast: false
  matrix:
    mode: [instrumentation, walltime]
runs-on: ubuntu-latest
\`\`\`

Both modes share \`ubuntu-latest\`. CodSpeed Macro Runners would give cleaner walltime numbers but they require an **organization-owned repo** (this repo lives under a personal account, see [docs](https://codspeed.io/docs/macro-runners)), so we trade some noise for accessibility. CodSpeed's statistical engine (multiple rounds + outlier rejection) compensates for the shared-runner variance reasonably well; if it turns out too noisy in practice we can revisit (move repo to org, set up a self-hosted runner, or drop the walltime job).

\`pytest-codspeed\` already supports both modes; \`CodSpeedHQ/action@v3\` picks the mode up from the matrix value, no nox/pytest changes needed.

## Notes

- Memory mode was considered but [docs](https://codspeed.io/docs/instruments/memory) say it tracks heap allocations only for Rust and C/C++ — our public surface is Python so it wouldn't measure anything useful.
- After this lands, PR #233 should start showing the wall-clock improvement on the CodSpeed dashboard (or at least surface real numbers the team can eyeball).