### PR TITLE
Avoid PyErr allocation on Union variant misses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/ermakov-oleg/serpyco-rs"
 
 [lib]
 name = "serpyco_rs"
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 pyo3 = { version = "0.27", features = ["extension-module", "py-clone"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/ermakov-oleg/serpyco-rs"
 
 [lib]
 name = "serpyco_rs"
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.27", features = ["extension-module", "py-clone"] }

--- a/bench/test_encoders.py
+++ b/bench/test_encoders.py
@@ -277,7 +277,7 @@ def test_load_union_miss_first(bench_or_check_refcount):
     class Foo:
         foo: int
 
-    # Первый вариант (Foo) ВСЕГДА промахнётся для int — измеряем стоимость промаха.
+    # First variant (Foo) always misses for an int — this measures the miss cost.
     serializer = Serializer(Union[Foo, int])
     data = 42
     bench_or_check_refcount.group = 'union'

--- a/bench/test_encoders.py
+++ b/bench/test_encoders.py
@@ -270,3 +270,15 @@ def test_load_union(bench_or_check_refcount):
     data = {'foo': 1}
     bench_or_check_refcount.group = 'union'
     bench_or_check_refcount(repeat(lambda: serializer.load(data)))
+
+
+def test_load_union_miss_first(bench_or_check_refcount):
+    @dataclass
+    class Foo:
+        foo: int
+
+    # Первый вариант (Foo) ВСЕГДА промахнётся для int — измеряем стоимость промаха.
+    serializer = Serializer(Union[Foo, int])
+    data = 42
+    bench_or_check_refcount.group = 'union'
+    bench_or_check_refcount(repeat(lambda: serializer.load(data)))

--- a/python/serpyco_rs/_type_info.py
+++ b/python/serpyco_rs/_type_info.py
@@ -8,7 +8,7 @@ _I = TypeVar('_I')
 _O = TypeVar('_O')
 
 
-@dataclasses.dataclass(slots=True, kw_only=True)
+@dataclasses.dataclass(slots=True, kw_only=True, unsafe_hash=True)
 class CustomEncoder(Generic[_I, _O]):
     serialize: Callable[[_I], _O] | None = None
     deserialize: Callable[[_O], _I] | None = None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod errors;
 mod python;
+mod serde_error;
 mod serializer;
 mod validator;
 

--- a/src/serde_error.rs
+++ b/src/serde_error.rs
@@ -1,0 +1,142 @@
+use pyo3::exceptions::PyException;
+use pyo3::prelude::*;
+use pyo3::types::PyType;
+
+use crate::errors::{ErrorItem, SchemaValidationError};
+use crate::validator::InstancePath;
+use crate::validator::errors::into_path;
+
+#[derive(Debug)]
+pub enum SerdeError {
+    Schema(SchemaError),
+    Py(PyErr),
+}
+
+#[derive(Debug)]
+pub struct SchemaError {
+    pub message: String,
+    pub path: String,
+    pub cause: Option<PyErr>,
+}
+
+impl SchemaError {
+    pub fn new(message: String, path: &InstancePath) -> Self {
+        Self {
+            message,
+            path: into_path(path),
+            cause: None,
+        }
+    }
+
+    pub fn with_cause(message: String, path: &InstancePath, cause: PyErr) -> Self {
+        Self {
+            message,
+            path: into_path(path),
+            cause: Some(cause),
+        }
+    }
+}
+
+impl From<PyErr> for SerdeError {
+    #[inline]
+    fn from(err: PyErr) -> Self {
+        SerdeError::Py(err)
+    }
+}
+
+impl From<SchemaError> for SerdeError {
+    #[inline]
+    fn from(err: SchemaError) -> Self {
+        SerdeError::Schema(err)
+    }
+}
+
+impl SerdeError {
+    /// Единственная точка конвертации в Python-ошибку — вызывается на FFI-границе.
+    pub fn into_py_err(self) -> PyErr {
+        match self {
+            SerdeError::Py(err) => err,
+            SerdeError::Schema(s) => Python::attach(|py| {
+                let errors: Vec<ErrorItem> = vec![ErrorItem::new(s.message, s.path)];
+                let py_err = PyErr::from_type(
+                    PyType::new::<SchemaValidationError>(py),
+                    ("Schema validation failed".to_string(), errors),
+                );
+                if let Some(cause) = s.cause {
+                    py_err.set_cause(py, Some(cause));
+                }
+                py_err
+            }),
+        }
+    }
+
+    /// Конвертер для PyErr из пользовательских callback'ов.
+    /// Обычные `Exception` оборачиваются в `Schema` с `cause` (отбрасываются в Union).
+    /// `BaseException`-only (`KeyboardInterrupt`, `SystemExit`) уходят в `Py` (всплывают).
+    pub fn from_user_callback(err: PyErr, path: &InstancePath) -> Self {
+        Python::attach(|py| {
+            if !err.is_instance_of::<PyException>(py) {
+                return SerdeError::Py(err);
+            }
+            SerdeError::Schema(SchemaError::with_cause(err.to_string(), path, err))
+        })
+    }
+}
+
+pub type SerdeResult<T> = Result<T, SerdeError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn init_python() {
+        pyo3::prepare_freethreaded_python();
+    }
+
+    #[test]
+    fn from_pyerr_makes_py_variant() {
+        init_python();
+        Python::attach(|_py| {
+            let pyerr = PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("boom");
+            let err: SerdeError = pyerr.into();
+            assert!(matches!(err, SerdeError::Py(_)));
+        });
+    }
+
+    #[test]
+    fn schema_new_materializes_empty_path() {
+        let path = InstancePath::new();
+        let err = SchemaError::new("nope".to_string(), &path);
+        assert_eq!(err.message, "nope");
+        assert_eq!(err.path, "");
+        assert!(err.cause.is_none());
+    }
+
+    #[test]
+    fn from_user_callback_wraps_value_error_as_schema() {
+        init_python();
+        Python::attach(|_py| {
+            let pyerr = PyErr::new::<pyo3::exceptions::PyValueError, _>("bad");
+            let path = InstancePath::new();
+            let err = SerdeError::from_user_callback(pyerr, &path);
+            match err {
+                SerdeError::Schema(s) => {
+                    assert!(s.cause.is_some());
+                    assert!(s.message.contains("bad"));
+                }
+                _ => panic!("expected Schema"),
+            }
+        });
+    }
+
+    #[test]
+    fn from_user_callback_keeps_keyboard_interrupt_as_py() {
+        init_python();
+        Python::attach(|_py| {
+            let pyerr = PyErr::new::<pyo3::exceptions::PyKeyboardInterrupt, _>("");
+            let path = InstancePath::new();
+            let err = SerdeError::from_user_callback(pyerr, &path);
+            assert!(matches!(err, SerdeError::Py(_)));
+        });
+    }
+}

--- a/src/serde_error.rs
+++ b/src/serde_error.rs
@@ -3,17 +3,15 @@ use pyo3::prelude::*;
 use pyo3::types::PyType;
 
 use crate::errors::{ErrorItem, SchemaValidationError};
-use crate::validator::InstancePath;
 use crate::validator::errors::into_path;
+use crate::validator::InstancePath;
 
-#[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) enum SerdeError {
     Schema(SchemaError),
     Py(PyErr),
 }
 
-#[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) struct SchemaError {
     pub(crate) message: String,
@@ -21,7 +19,6 @@ pub(crate) struct SchemaError {
     pub(crate) cause: Option<PyErr>,
 }
 
-#[allow(dead_code)]
 impl SchemaError {
     pub(crate) fn new(message: String, path: &InstancePath) -> Self {
         Self {
@@ -54,7 +51,6 @@ impl From<SchemaError> for SerdeError {
     }
 }
 
-#[allow(dead_code)]
 impl SerdeError {
     /// Единственная точка конвертации в Python-ошибку — вызывается на FFI-границе.
     pub(crate) fn into_py_err(self) -> PyErr {
@@ -87,5 +83,4 @@ impl SerdeError {
     }
 }
 
-#[allow(dead_code)]
 pub(crate) type SerdeResult<T> = Result<T, SerdeError>;

--- a/src/serde_error.rs
+++ b/src/serde_error.rs
@@ -6,21 +6,24 @@ use crate::errors::{ErrorItem, SchemaValidationError};
 use crate::validator::InstancePath;
 use crate::validator::errors::into_path;
 
+#[allow(dead_code)]
 #[derive(Debug)]
-pub enum SerdeError {
+pub(crate) enum SerdeError {
     Schema(SchemaError),
     Py(PyErr),
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
-pub struct SchemaError {
-    pub message: String,
-    pub path: String,
-    pub cause: Option<PyErr>,
+pub(crate) struct SchemaError {
+    pub(crate) message: String,
+    pub(crate) path: String,
+    pub(crate) cause: Option<PyErr>,
 }
 
+#[allow(dead_code)]
 impl SchemaError {
-    pub fn new(message: String, path: &InstancePath) -> Self {
+    pub(crate) fn new(message: String, path: &InstancePath) -> Self {
         Self {
             message,
             path: into_path(path),
@@ -28,7 +31,7 @@ impl SchemaError {
         }
     }
 
-    pub fn with_cause(message: String, path: &InstancePath, cause: PyErr) -> Self {
+    pub(crate) fn with_cause(message: String, path: &InstancePath, cause: PyErr) -> Self {
         Self {
             message,
             path: into_path(path),
@@ -51,9 +54,10 @@ impl From<SchemaError> for SerdeError {
     }
 }
 
+#[allow(dead_code)]
 impl SerdeError {
     /// Единственная точка конвертации в Python-ошибку — вызывается на FFI-границе.
-    pub fn into_py_err(self) -> PyErr {
+    pub(crate) fn into_py_err(self) -> PyErr {
         match self {
             SerdeError::Py(err) => err,
             SerdeError::Schema(s) => Python::attach(|py| {
@@ -73,7 +77,7 @@ impl SerdeError {
     /// Конвертер для PyErr из пользовательских callback'ов.
     /// Обычные `Exception` оборачиваются в `Schema` с `cause` (отбрасываются в Union).
     /// `BaseException`-only (`KeyboardInterrupt`, `SystemExit`) уходят в `Py` (всплывают).
-    pub fn from_user_callback(err: PyErr, path: &InstancePath) -> Self {
+    pub(crate) fn from_user_callback(err: PyErr, path: &InstancePath) -> Self {
         Python::attach(|py| {
             if !err.is_instance_of::<PyException>(py) {
                 return SerdeError::Py(err);
@@ -83,60 +87,5 @@ impl SerdeError {
     }
 }
 
-pub type SerdeResult<T> = Result<T, SerdeError>;
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn init_python() {
-        pyo3::prepare_freethreaded_python();
-    }
-
-    #[test]
-    fn from_pyerr_makes_py_variant() {
-        init_python();
-        Python::attach(|_py| {
-            let pyerr = PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("boom");
-            let err: SerdeError = pyerr.into();
-            assert!(matches!(err, SerdeError::Py(_)));
-        });
-    }
-
-    #[test]
-    fn schema_new_materializes_empty_path() {
-        let path = InstancePath::new();
-        let err = SchemaError::new("nope".to_string(), &path);
-        assert_eq!(err.message, "nope");
-        assert_eq!(err.path, "");
-        assert!(err.cause.is_none());
-    }
-
-    #[test]
-    fn from_user_callback_wraps_value_error_as_schema() {
-        init_python();
-        Python::attach(|_py| {
-            let pyerr = PyErr::new::<pyo3::exceptions::PyValueError, _>("bad");
-            let path = InstancePath::new();
-            let err = SerdeError::from_user_callback(pyerr, &path);
-            match err {
-                SerdeError::Schema(s) => {
-                    assert!(s.cause.is_some());
-                    assert!(s.message.contains("bad"));
-                }
-                _ => panic!("expected Schema"),
-            }
-        });
-    }
-
-    #[test]
-    fn from_user_callback_keeps_keyboard_interrupt_as_py() {
-        init_python();
-        Python::attach(|_py| {
-            let pyerr = PyErr::new::<pyo3::exceptions::PyKeyboardInterrupt, _>("");
-            let path = InstancePath::new();
-            let err = SerdeError::from_user_callback(pyerr, &path);
-            assert!(matches!(err, SerdeError::Py(_)));
-        });
-    }
-}
+#[allow(dead_code)]
+pub(crate) type SerdeResult<T> = Result<T, SerdeError>;

--- a/src/serde_error.rs
+++ b/src/serde_error.rs
@@ -52,7 +52,7 @@ impl From<SchemaError> for SerdeError {
 }
 
 impl SerdeError {
-    /// Единственная точка конвертации в Python-ошибку — вызывается на FFI-границе.
+    /// Single conversion point to a Python error — invoked at the FFI boundary.
     pub(crate) fn into_py_err(self) -> PyErr {
         match self {
             SerdeError::Py(err) => err,
@@ -70,9 +70,9 @@ impl SerdeError {
         }
     }
 
-    /// Конвертер для PyErr из пользовательских callback'ов.
-    /// Обычные `Exception` оборачиваются в `Schema` с `cause` (отбрасываются в Union).
-    /// `BaseException`-only (`KeyboardInterrupt`, `SystemExit`) уходят в `Py` (всплывают).
+    /// Wraps a PyErr raised from a user callback.
+    /// Regular `Exception` subclasses become `Schema` with `cause` (discarded inside Union).
+    /// `BaseException`-only types (`KeyboardInterrupt`, `SystemExit`) go to `Py` and propagate.
     pub(crate) fn from_user_callback(err: PyErr, path: &InstancePath) -> Self {
         Python::attach(|py| {
             if !err.is_instance_of::<PyException>(py) {

--- a/src/serializer/encoders.rs
+++ b/src/serializer/encoders.rs
@@ -22,23 +22,24 @@ use crate::python::{
     py_list_set_item, py_tuple_set_item, set_attr_unchecked,
 };
 use crate::python::{DecimalTypeInfo, FloatTypeInfo, IntegerTypeInfo, StringTypeInfo};
+use crate::serde_error::{SerdeError, SerdeResult};
 use crate::validator::validators::{
     check_bounds, check_length, check_sequence_bounds, check_sequence_size, invalid_enum_item,
-    invalid_type, invalid_type_dump, missing_required_property, no_encoder_for_discriminator,
-    str_as_bool,
+    invalid_type, invalid_type_dump, invalid_type_dump_err, invalid_type_err,
+    missing_required_property, no_encoder_for_discriminator, str_as_bool,
 };
-use crate::validator::{map_py_err_to_schema_validation_error, Context, InstancePath};
+use crate::validator::{Context, InstancePath};
 
 pub type TEncoder = dyn Encoder + Send + Sync;
 
-pub trait Encoder: DynClone + Debug {
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>>;
+pub(crate) trait Encoder: DynClone + Debug {
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>>;
     fn load<'a>(
         &self,
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>>;
+    ) -> SerdeResult<Bound<'a, PyAny>>;
 
     fn as_container_encoder(&self) -> Option<&dyn ContainerEncoder> {
         None
@@ -69,7 +70,7 @@ pub struct NoopEncoder;
 
 impl Encoder for NoopEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
         Ok(value.clone())
     }
 
@@ -79,7 +80,7 @@ impl Encoder for NoopEncoder {
         value: &Bound<'a, PyAny>,
         _instance_path: &InstancePath,
         _ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         Ok(value.clone())
     }
 }
@@ -89,7 +90,7 @@ pub struct NoneEncoder;
 
 impl Encoder for NoneEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
         Ok(value.clone())
     }
 
@@ -99,7 +100,7 @@ impl Encoder for NoneEncoder {
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         _ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         if value.is_none() {
             return Ok(value.clone());
         }
@@ -112,7 +113,7 @@ pub struct NeverEncoder;
 
 impl Encoder for NeverEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
         // Never type should not have any values to dump
         invalid_type_dump!("Never", value)
     }
@@ -123,7 +124,7 @@ impl Encoder for NeverEncoder {
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         _ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         // Never type cannot be loaded - any value is invalid
         invalid_type!("Never (no value allowed)", value, instance_path)
     }
@@ -136,7 +137,7 @@ pub struct IntEncoder {
 
 impl Encoder for IntEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
         Ok(value.clone())
     }
 
@@ -146,7 +147,7 @@ impl Encoder for IntEncoder {
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         if let Ok(val) = value.cast_exact::<PyInt>() {
             check_bounds!(val.extract()?, self.type_info, instance_path)?;
             return Ok(value.clone());
@@ -155,7 +156,7 @@ impl Encoder for IntEncoder {
             if let Ok(val) = value.cast::<PyString>() {
                 if let Ok(val) = val.to_str()?.parse::<i64>() {
                     check_bounds!(val, self.type_info, instance_path)?;
-                    return val.into_bound_py_any(value.py());
+                    return Ok(val.into_bound_py_any(value.py())?);
                 }
             }
         }
@@ -170,7 +171,7 @@ pub struct FloatEncoder {
 
 impl Encoder for FloatEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
         Ok(value.clone())
     }
     #[inline]
@@ -179,7 +180,7 @@ impl Encoder for FloatEncoder {
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         if let Ok(val) = value.cast::<PyInt>() {
             check_bounds!(val.extract()?, self.type_info, instance_path)?;
             return Ok(value.clone());
@@ -192,7 +193,7 @@ impl Encoder for FloatEncoder {
             if let Ok(val) = value.cast::<PyString>() {
                 if let Ok(val) = val.to_str()?.parse::<f64>() {
                     check_bounds!(val, self.type_info, instance_path)?;
-                    return val.into_bound_py_any(value.py());
+                    return Ok(val.into_bound_py_any(value.py())?);
                 }
             }
         }
@@ -208,7 +209,7 @@ pub struct DecimalEncoder {
 
 impl Encoder for DecimalEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
         Ok(value.str()?.into_any())
     }
 
@@ -218,7 +219,7 @@ impl Encoder for DecimalEncoder {
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         _ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         let valid = if let Ok(val) = value.cast::<PyFloat>() {
             check_bounds!(val.value(), self.type_info, instance_path)?;
             true
@@ -238,7 +239,7 @@ impl Encoder for DecimalEncoder {
         };
         if valid {
             let str_value = value.str().expect("Failed to convert value to string.");
-            self.decimal_cls.bind(value.py()).call1((str_value,))
+            Ok(self.decimal_cls.bind(value.py()).call1((str_value,))?)
         } else {
             invalid_type!("decimal", value, instance_path)
         }
@@ -252,7 +253,7 @@ pub struct StringEncoder {
 
 impl Encoder for StringEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
         Ok(value.clone())
     }
 
@@ -262,7 +263,7 @@ impl Encoder for StringEncoder {
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         _ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         if let Ok(val) = value.cast::<PyString>() {
             check_length(
                 val,
@@ -282,7 +283,7 @@ pub struct BooleanEncoder {}
 
 impl Encoder for BooleanEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
         Ok(value.clone())
     }
 
@@ -292,14 +293,14 @@ impl Encoder for BooleanEncoder {
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         if let Ok(_val) = value.cast::<PyBool>() {
             return Ok(value.clone());
         }
         if ctx.try_cast_from_string {
             if let Ok(val) = value.cast::<PyString>() {
                 if let Some(val) = str_as_bool(val.to_str()?) {
-                    return val.into_bound_py_any(value.py());
+                    return Ok(val.into_bound_py_any(value.py())?);
                 }
             }
         }
@@ -313,7 +314,7 @@ pub struct BytesEncoder {}
 
 impl Encoder for BytesEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
         Ok(value.clone())
     }
 
@@ -323,7 +324,7 @@ impl Encoder for BytesEncoder {
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         _ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         if let Ok(_val) = value.cast::<PyBytes>() {
             Ok(value.clone())
         } else {
@@ -341,7 +342,7 @@ pub struct DictionaryEncoder {
 
 impl Encoder for DictionaryEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
         if let Ok(dict) = value.cast::<PyDict>() {
             let result_dict = create_py_dict_known_size(dict.py(), dict.len());
             for (k, v) in dict.iter() {
@@ -363,7 +364,7 @@ impl Encoder for DictionaryEncoder {
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         if let Ok(val) = value.cast::<PyDict>() {
             let result_dict = create_py_dict_known_size(val.py(), val.len());
             for (k, v) in val.iter() {
@@ -398,7 +399,7 @@ pub struct ArrayEncoder {
 
 impl Encoder for ArrayEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
         if let Ok(list) = value.cast::<PyList>() {
             let size = list.len();
             let result = create_py_list(value.py(), size);
@@ -421,7 +422,7 @@ impl Encoder for ArrayEncoder {
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         if let Ok(val) = value.cast::<PyList>() {
             let size = val.len();
             check_sequence_bounds(
@@ -479,7 +480,7 @@ impl Field {
         &self,
         py: Python<'a>,
         instance_path: &InstancePath,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         match (&self.default, &self.default_factory) {
             (Some(val), _) => Ok(val.bind(py).clone()),
             (_, Some(factory)) => Ok(factory.bind(py).call0()?),
@@ -493,7 +494,7 @@ impl Field {
         instance_path: &InstancePath,
         ctx: &Context,
         used_keys: &Py<PySet>,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         if self.is_flattened {
             if self.is_dict_flatten {
                 let remaining_dict = create_remaining_dict(val, used_keys)?;
@@ -516,14 +517,17 @@ impl Field {
 
 impl Encoder for EntityEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
         let dict = create_py_dict_known_size(value.py(), self.fields.len());
         for field in &self.fields {
             let field_val = value.getattr(&field.name)?;
             let dump_result = field.encoder.dump(&field_val)?;
             if field.required || !self.omit_none || !dump_result.is_none() {
                 if field.is_flattened {
-                    dict.update(dump_result.cast::<pyo3::types::PyMapping>()?)?;
+                    let mapping = dump_result
+                        .cast::<pyo3::types::PyMapping>()
+                        .map_err(PyErr::from)?;
+                    dict.update(mapping)?;
                 } else {
                     py_dict_set_item(&dict, field.dict_key.as_ptr(), dump_result)?;
                 }
@@ -538,7 +542,7 @@ impl Encoder for EntityEncoder {
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         let Ok(val) = value.cast::<PyDict>() else {
             invalid_type!("object", value, instance_path)
         };
@@ -607,7 +611,7 @@ pub struct TypedDictEncoder {
 
 impl Encoder for TypedDictEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
         let value = match value.cast::<PyDict>() {
             Ok(val) => val,
             _ => invalid_type_dump!("dict", value),
@@ -618,10 +622,10 @@ impl Encoder for TypedDictEncoder {
                 Ok(Some(val)) => val,
                 _ => {
                     if field.required {
-                        return Err(ValidationError::new_err(format!(
+                        return Err(SerdeError::Py(ValidationError::new_err(format!(
                             "data dictionary is missing required parameter {}",
                             &field.name
-                        )));
+                        ))));
                     }
                     continue;
                 }
@@ -629,7 +633,10 @@ impl Encoder for TypedDictEncoder {
             let dump_result = field.encoder.dump(&field_val)?;
             if field.required || !self.omit_none || !dump_result.is_none() {
                 if field.is_flattened {
-                    dict.update(dump_result.cast::<pyo3::types::PyMapping>()?)?;
+                    let mapping = dump_result
+                        .cast::<pyo3::types::PyMapping>()
+                        .map_err(PyErr::from)?;
+                    dict.update(mapping)?;
                 } else {
                     py_dict_set_item(&dict, field.dict_key.as_ptr(), dump_result)?;
                 }
@@ -644,7 +651,7 @@ impl Encoder for TypedDictEncoder {
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         let Ok(value) = value.cast::<PyDict>() else {
             invalid_type_dump!("dict", value);
         };
@@ -673,7 +680,7 @@ pub struct UUIDEncoder {
 
 impl Encoder for UUIDEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
         Ok(value.str()?.into_any())
     }
 
@@ -683,7 +690,7 @@ impl Encoder for UUIDEncoder {
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         _ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         if let Ok(val) = value.cast::<PyString>() {
             if Uuid::parse_str(val.to_str()?).is_ok() {
                 if let Ok(result) = self.uuid_cls.bind(value.py()).call1((val,)) {
@@ -704,7 +711,7 @@ pub struct EnumEncoder {
 
 impl Encoder for EnumEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
         let id = value.as_ptr() as *const _ as usize;
         if let Some(py_item) = self.dump_map.get(&id) {
             return Ok(py_item.bind(value.py()).clone());
@@ -718,7 +725,7 @@ impl Encoder for EnumEncoder {
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         match self.load_map.bind(value.py()).get_item(value) {
             Ok(Some(val)) => Ok(val),
             _ if ctx.try_cast_from_string => {
@@ -741,7 +748,7 @@ pub struct LiteralEncoder {
 
 impl Encoder for LiteralEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
         if let Ok(Some(py_item)) = self.dump_map.bind(value.py()).get_item(value) {
             return Ok(py_item);
         }
@@ -754,7 +761,7 @@ impl Encoder for LiteralEncoder {
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         match self.load_map.bind(value.py()).get_item(value) {
             Ok(Some(val)) => Ok(val),
             _ if ctx.try_cast_from_string => {
@@ -775,7 +782,7 @@ pub struct OptionalEncoder {
 
 impl Encoder for OptionalEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
         if value.is_none() {
             Ok(value.clone())
         } else {
@@ -789,7 +796,7 @@ impl Encoder for OptionalEncoder {
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         if value.is_none() {
             Ok(value.clone())
         } else {
@@ -809,7 +816,7 @@ pub struct TupleEncoder {
 
 impl Encoder for TupleEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
         if let Ok(seq) = value.cast::<PySequence>() {
             let seq_len = seq.len()?;
             check_sequence_size(seq, seq_len, self.encoders.len(), None)?;
@@ -832,7 +839,7 @@ impl Encoder for TupleEncoder {
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         // Check sequence is not str
         if let Ok(seq) = value.cast::<PySequence>() {
             if value.is_instance_of::<PyString>() {
@@ -866,14 +873,15 @@ pub struct UnionEncoder {
 
 impl Encoder for UnionEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
         for encoder in &self.encoders {
-            let result = encoder.dump(value);
-            if result.is_ok() {
-                return result;
+            match encoder.dump(value) {
+                Ok(v) => return Ok(v),
+                Err(SerdeError::Schema(_)) => continue,
+                Err(e @ SerdeError::Py(_)) => return Err(e),
             }
         }
-        invalid_type_dump!(&self.repr, value)
+        Err(invalid_type_dump_err(&self.repr, value))
     }
 
     #[inline]
@@ -882,14 +890,15 @@ impl Encoder for UnionEncoder {
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         for encoder in &self.encoders {
-            let result = encoder.load(value, instance_path, ctx);
-            if result.is_ok() {
-                return result;
+            match encoder.load(value, instance_path, ctx) {
+                Ok(v) => return Ok(v),
+                Err(SerdeError::Schema(_)) => continue,
+                Err(e @ SerdeError::Py(_)) => return Err(e),
             }
         }
-        invalid_type!(&self.repr, value, instance_path)
+        Err(invalid_type_err(&self.repr, value, instance_path))
     }
 }
 
@@ -927,7 +936,7 @@ pub struct DiscriminatedUnionEncoder {
 
 impl Encoder for DiscriminatedUnionEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
         let key = match value.getattr(&self.dump_discriminator) {
             Ok(val) => val,
             Err(_) => {
@@ -954,7 +963,7 @@ impl Encoder for DiscriminatedUnionEncoder {
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         if let Ok(val) = value.cast::<PyDict>() {
             let key = match val.get_item(&self.load_discriminator) {
                 Ok(Some(k)) => k,
@@ -986,10 +995,10 @@ pub struct TimeEncoder {}
 
 impl Encoder for TimeEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
-        let py_time = value.cast::<PyTime>()?;
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
+        let py_time = value.cast::<PyTime>().map_err(PyErr::from)?;
         let result = dump_time(py_time)?;
-        result.into_bound_py_any(value.py())
+        Ok(result.into_bound_py_any(value.py())?)
     }
 
     #[inline]
@@ -998,7 +1007,7 @@ impl Encoder for TimeEncoder {
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         _ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         if let Ok(val) = value.cast::<PyString>() {
             if let Ok(result) = parse_time(value.py(), val.to_str()?) {
                 return Ok(result.into_any());
@@ -1015,10 +1024,10 @@ pub struct DateTimeEncoder {
 
 impl Encoder for DateTimeEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
-        let py_datetime = value.cast::<PyDateTime>()?;
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
+        let py_datetime = value.cast::<PyDateTime>().map_err(PyErr::from)?;
         let result = dump_datetime(py_datetime, self.naive_datetime_to_utc)?;
-        result.into_bound_py_any(value.py())
+        Ok(result.into_bound_py_any(value.py())?)
     }
 
     #[inline]
@@ -1027,7 +1036,7 @@ impl Encoder for DateTimeEncoder {
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         _ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         if let Ok(val) = value.cast::<PyString>() {
             if let Ok(result) = parse_datetime(value.py(), val.to_str()?) {
                 return Ok(result.into_any());
@@ -1042,10 +1051,10 @@ pub struct DateEncoder {}
 
 impl Encoder for DateEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
-        let py_date = value.cast::<PyDate>()?;
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
+        let py_date = value.cast::<PyDate>().map_err(PyErr::from)?;
         let result = dump_date(py_date);
-        result.into_bound_py_any(value.py())
+        Ok(result.into_bound_py_any(value.py())?)
     }
 
     #[inline]
@@ -1054,7 +1063,7 @@ impl Encoder for DateEncoder {
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         _ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         if let Ok(val) = value.cast::<PyString>() {
             if let Ok(result) = parse_date(value.py(), val.to_str()?) {
                 return Ok(result.into_any());
@@ -1083,7 +1092,7 @@ pub struct LazyEncoder {
 
 impl Encoder for LazyEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
         match self.inner.borrow().as_ref() {
             Some(encoder) => match encoder {
                 Encoders::Entity(encoder) => encoder.dump(value),
@@ -1095,9 +1104,9 @@ impl Encoder for LazyEncoder {
                 Encoders::Optional(encoder) => encoder.dump(value),
                 Encoders::Dict(encoder) => encoder.dump(value),
             },
-            None => Err(PyRuntimeError::new_err(
+            None => Err(SerdeError::Py(PyRuntimeError::new_err(
                 "[RUST] Invalid recursive encoder".to_string(),
-            )),
+            ))),
         }
     }
 
@@ -1107,7 +1116,7 @@ impl Encoder for LazyEncoder {
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         match self.inner.borrow().as_ref() {
             Some(encoder) => match encoder {
                 Encoders::Entity(encoder) => encoder.load(value, instance_path, ctx),
@@ -1119,9 +1128,9 @@ impl Encoder for LazyEncoder {
                 Encoders::DiscriminatedUnion(encoder) => encoder.load(value, instance_path, ctx),
                 Encoders::Dict(encoder) => encoder.load(value, instance_path, ctx),
             },
-            None => Err(PyRuntimeError::new_err(
+            None => Err(SerdeError::Py(PyRuntimeError::new_err(
                 "[RUST] Invalid recursive encoder".to_string(),
-            )),
+            ))),
         }
     }
 }
@@ -1135,9 +1144,12 @@ pub struct CustomEncoder {
 
 impl Encoder for CustomEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
         match self.dump {
-            Some(ref dump) => dump.bind(value.py()).call1((value,)),
+            Some(ref dump) => dump
+                .bind(value.py())
+                .call1((value,))
+                .map_err(|err| SerdeError::from_user_callback(err, &InstancePath::new())),
             None => self.inner.dump(value),
         }
     }
@@ -1148,11 +1160,12 @@ impl Encoder for CustomEncoder {
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
+    ) -> SerdeResult<Bound<'a, PyAny>> {
         match self.load {
-            Some(ref load) => load.bind(value.py()).call1((value,)).map_err(|err| {
-                map_py_err_to_schema_validation_error(value.py(), err, instance_path)
-            }),
+            Some(ref load) => load
+                .bind(value.py())
+                .call1((value,))
+                .map_err(|err| SerdeError::from_user_callback(err, instance_path)),
             None => self.inner.load(value, instance_path, ctx),
         }
     }
@@ -1170,8 +1183,11 @@ pub struct CustomTypeEncoder {
 
 impl Encoder for CustomTypeEncoder {
     #[inline]
-    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> PyResult<Bound<'a, PyAny>> {
-        self.dump.bind(value.py()).call1((value,))
+    fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
+        self.dump
+            .bind(value.py())
+            .call1((value,))
+            .map_err(|err| SerdeError::from_user_callback(err, &InstancePath::new()))
     }
 
     #[inline]
@@ -1180,8 +1196,10 @@ impl Encoder for CustomTypeEncoder {
         value: &Bound<'a, PyAny>,
         instance_path: &InstancePath,
         _ctx: &Context,
-    ) -> PyResult<Bound<'a, PyAny>> {
-        let result = self.load.bind(value.py()).call1((value,));
-        result.map_err(|err| map_py_err_to_schema_validation_error(value.py(), err, instance_path))
+    ) -> SerdeResult<Bound<'a, PyAny>> {
+        self.load
+            .bind(value.py())
+            .call1((value,))
+            .map_err(|err| SerdeError::from_user_callback(err, instance_path))
     }
 }

--- a/src/serializer/encoders.rs
+++ b/src/serializer/encoders.rs
@@ -996,7 +996,9 @@ pub struct TimeEncoder {}
 impl Encoder for TimeEncoder {
     #[inline]
     fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
-        let py_time = value.cast::<PyTime>().map_err(PyErr::from)?;
+        let py_time = value
+            .cast::<PyTime>()
+            .map_err(|_| invalid_type_dump_err("time", value))?;
         let result = dump_time(py_time)?;
         Ok(result.into_bound_py_any(value.py())?)
     }
@@ -1025,7 +1027,9 @@ pub struct DateTimeEncoder {
 impl Encoder for DateTimeEncoder {
     #[inline]
     fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
-        let py_datetime = value.cast::<PyDateTime>().map_err(PyErr::from)?;
+        let py_datetime = value
+            .cast::<PyDateTime>()
+            .map_err(|_| invalid_type_dump_err("datetime", value))?;
         let result = dump_datetime(py_datetime, self.naive_datetime_to_utc)?;
         Ok(result.into_bound_py_any(value.py())?)
     }
@@ -1052,7 +1056,9 @@ pub struct DateEncoder {}
 impl Encoder for DateEncoder {
     #[inline]
     fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
-        let py_date = value.cast::<PyDate>().map_err(PyErr::from)?;
+        let py_date = value
+            .cast::<PyDate>()
+            .map_err(|_| invalid_type_dump_err("date", value))?;
         let result = dump_date(py_date);
         Ok(result.into_bound_py_any(value.py())?)
     }

--- a/src/serializer/main.rs
+++ b/src/serializer/main.rs
@@ -8,6 +8,7 @@ use pyo3::types::{PyDict, PyList, PyMapping, PyString};
 use pyo3::{intern, PyAny, PyResult};
 
 use crate::python::{get_object_type, BaseTypeInfo, EntityFieldInfo, Type};
+use crate::serde_error::SerdeError;
 use crate::serializer::encoders::{
     BooleanEncoder, BytesEncoder, CustomTypeEncoder, DiscriminatorKey, FloatEncoder, IntEncoder,
     LiteralEncoder, NeverEncoder, NoneEncoder, QueryFields, StringEncoder, TypedDictEncoder,
@@ -29,7 +30,7 @@ type CustomEncoderFns = (Option<Py<PyAny>>, Option<Py<PyAny>>);
 #[pyclass(frozen, module = "serde_json")]
 #[derive(Debug)]
 pub struct Serializer {
-    pub encoder: Box<TEncoder>,
+    pub(crate) encoder: Box<TEncoder>,
 }
 
 #[pymethods]
@@ -52,14 +53,16 @@ impl Serializer {
 
     #[inline]
     pub fn dump<'py>(&'py self, value: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
-        self.encoder.dump(value)
+        self.encoder.dump(value).map_err(SerdeError::into_py_err)
     }
 
     #[inline]
     pub fn load<'py>(&'py self, value: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
         let instance_path = InstancePath::new();
         let ctx = Context::new(false);
-        self.encoder.load(value, &instance_path, &ctx)
+        self.encoder
+            .load(value, &instance_path, &ctx)
+            .map_err(SerdeError::into_py_err)
     }
 
     #[inline]
@@ -116,7 +119,9 @@ impl Serializer {
             }
         };
 
-        encoder.load(&new_data, &instance_path, &ctx)
+        encoder
+            .load(&new_data, &instance_path, &ctx)
+            .map_err(SerdeError::into_py_err)
     }
 }
 

--- a/src/validator/errors.rs
+++ b/src/validator/errors.rs
@@ -1,27 +1,5 @@
-use pyo3::types::PyType;
-use pyo3::{PyErr, PyResult, Python};
-
-use crate::errors::ErrorItem;
-use crate::errors::SchemaValidationError;
 use crate::validator::context::PathChunk;
 use crate::validator::InstancePath;
-
-pub fn raise_error<T: Into<String>>(error: T, instance_path: &InstancePath) -> PyResult<()> {
-    Python::attach(|py| {
-        let errors: Vec<ErrorItem> = vec![into_err_item(error, instance_path)];
-
-        let pyerror_type = PyType::new::<SchemaValidationError>(py);
-        Err(PyErr::from_type(
-            pyerror_type,
-            ("Schema validation failed".to_string(), errors),
-        ))
-    })
-}
-
-fn into_err_item<T: Into<String>>(error: T, instance_path: &InstancePath) -> ErrorItem {
-    let instance_path = into_path(instance_path);
-    ErrorItem::new(error.into(), instance_path)
-}
 
 pub(crate) fn into_path(pointer: &InstancePath) -> String {
     let mut path = vec![];
@@ -35,19 +13,4 @@ pub(crate) fn into_path(pointer: &InstancePath) -> String {
         };
     }
     path.join("/")
-}
-
-pub fn map_py_err_to_schema_validation_error(
-    py: Python<'_>,
-    error: PyErr,
-    instance_path: &InstancePath,
-) -> PyErr {
-    let error_message = format!("{}", &error);
-    let instance_path = into_path(instance_path);
-    let err = PyErr::new::<SchemaValidationError, _>((
-        "Schema validation failed".to_string(),
-        vec![ErrorItem::new(error_message, instance_path)],
-    ));
-    err.set_cause(py, Some(error));
-    err
 }

--- a/src/validator/errors.rs
+++ b/src/validator/errors.rs
@@ -23,7 +23,7 @@ fn into_err_item<T: Into<String>>(error: T, instance_path: &InstancePath) -> Err
     ErrorItem::new(error.into(), instance_path)
 }
 
-fn into_path(pointer: &InstancePath) -> String {
+pub(crate) fn into_path(pointer: &InstancePath) -> String {
     let mut path = vec![];
     for chunk in pointer.to_vec() {
         match chunk {

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -1,5 +1,5 @@
 mod context;
-mod errors;
+pub(crate) mod errors;
 pub mod validators;
 
 pub use context::{Context, InstancePath};

--- a/src/validator/mod.rs
+++ b/src/validator/mod.rs
@@ -3,4 +3,3 @@ pub(crate) mod errors;
 pub mod validators;
 
 pub use context::{Context, InstancePath};
-pub use errors::{map_py_err_to_schema_validation_error, raise_error};

--- a/src/validator/validators.rs
+++ b/src/validator/validators.rs
@@ -1,8 +1,10 @@
-use crate::validator::{raise_error, InstancePath};
+use crate::python::fmt_py;
+use crate::serde_error::{SchemaError, SerdeError};
+use crate::validator::InstancePath;
 
 use pyo3::prelude::PyAnyMethods;
 use pyo3::types::{PyList, PySequence, PyString};
-use pyo3::{Bound, PyAny, PyErr, PyResult};
+use pyo3::{Bound, PyAny};
 use std::cmp::Ordering;
 use std::fmt::Display;
 
@@ -11,17 +13,18 @@ pub fn check_lower_bound<T>(
     min: Option<T>,
     inclusive: bool,
     instance_path: &InstancePath,
-) -> PyResult<()>
+) -> Result<(), SerdeError>
 where
     T: PartialOrd + Display,
 {
     if let Some(min) = min {
         let violates = if inclusive { val < min } else { val <= min };
         if violates {
-            raise_error(
+            return Err(SchemaError::new(
                 format!("{val} is less than the minimum of {min}"),
                 instance_path,
-            )?;
+            )
+            .into());
         }
     }
     Ok(())
@@ -32,17 +35,18 @@ pub fn check_upper_bound<T>(
     max: Option<T>,
     inclusive: bool,
     instance_path: &InstancePath,
-) -> PyResult<()>
+) -> Result<(), SerdeError>
 where
     T: PartialOrd + Display,
 {
     if let Some(max) = max {
         let violates = if inclusive { val > max } else { val >= max };
         if violates {
-            raise_error(
+            return Err(SchemaError::new(
                 format!("{val} is greater than the maximum of {max}"),
                 instance_path,
-            )?;
+            )
+            .into());
         }
     }
     Ok(())
@@ -55,7 +59,7 @@ pub fn _check_bounds<T>(
     inclusive_min: bool,
     inclusive_max: bool,
     instance_path: &InstancePath,
-) -> PyResult<()>
+) -> Result<(), SerdeError>
 where
     T: PartialOrd + Display + Copy,
 {
@@ -85,13 +89,14 @@ pub fn check_min_length(
     len: usize,
     min: Option<usize>,
     instance_path: &InstancePath,
-) -> PyResult<()> {
+) -> Result<(), SerdeError> {
     if let Some(min) = min {
         if len < min {
-            raise_error(
+            return Err(SchemaError::new(
                 format!(r#""{val}" is shorter than {min} characters"#),
                 instance_path,
-            )?;
+            )
+            .into());
         }
     }
     Ok(())
@@ -102,13 +107,14 @@ pub fn check_max_length(
     len: usize,
     max: Option<usize>,
     instance_path: &InstancePath,
-) -> PyResult<()> {
+) -> Result<(), SerdeError> {
     if let Some(max) = max {
         if len > max {
-            raise_error(
+            return Err(SchemaError::new(
                 format!(r#""{val}" is longer than {max} characters"#),
                 instance_path,
-            )?;
+            )
+            .into());
         }
     }
     Ok(())
@@ -119,7 +125,7 @@ pub fn check_length(
     min: Option<usize>,
     max: Option<usize>,
     instance_path: &InstancePath,
-) -> PyResult<()> {
+) -> Result<(), SerdeError> {
     if min.is_none() && max.is_none() {
         return Ok(());
     }
@@ -130,13 +136,13 @@ pub fn check_length(
 }
 
 #[cold]
-pub fn missing_required_property(property: &str, instance_path: &InstancePath) -> PyErr {
+pub fn missing_required_property(property: &str, instance_path: &InstancePath) -> SerdeError {
     let instance_path = instance_path.push(property);
-    raise_error(
+    SchemaError::new(
         format!(r#""{property}" is a required property"#),
         &instance_path,
     )
-    .unwrap_err()
+    .into()
 }
 
 pub fn check_sequence_size(
@@ -144,22 +150,16 @@ pub fn check_sequence_size(
     seq_len: usize,
     size: usize,
     instance_path: Option<&InstancePath>,
-) -> PyResult<()> {
+) -> Result<(), SerdeError> {
     match seq_len.cmp(&size) {
         Ordering::Equal => Ok(()),
         Ordering::Less => {
-            let instance_path = instance_path.cloned().unwrap_or(InstancePath::new());
-            raise_error(
-                format!(r#"{val} has less than {size} items"#),
-                &instance_path,
-            )
+            let path = instance_path.cloned().unwrap_or_else(InstancePath::new);
+            Err(SchemaError::new(format!(r#"{val} has less than {size} items"#), &path).into())
         }
         Ordering::Greater => {
-            let instance_path = instance_path.cloned().unwrap_or(InstancePath::new());
-            raise_error(
-                format!(r#"{val} has more than {size} items"#),
-                &instance_path,
-            )
+            let path = instance_path.cloned().unwrap_or_else(InstancePath::new);
+            Err(SchemaError::new(format!(r#"{val} has more than {size} items"#), &path).into())
         }
     }
 }
@@ -170,26 +170,24 @@ pub fn check_sequence_bounds(
     min: Option<usize>,
     max: Option<usize>,
     instance_path: Option<&InstancePath>,
-) -> PyResult<()> {
+) -> Result<(), SerdeError> {
     if min.is_none() && max.is_none() {
         return Ok(());
     }
     if let Some(min) = min {
         if seq_len < min {
-            let instance_path = instance_path.cloned().unwrap_or(InstancePath::new());
-            raise_error(
-                format!(r#"{val} has less than {min} items"#),
-                &instance_path,
-            )?;
+            let path = instance_path.cloned().unwrap_or_else(InstancePath::new);
+            return Err(
+                SchemaError::new(format!(r#"{val} has less than {min} items"#), &path).into(),
+            );
         }
     }
     if let Some(max) = max {
         if seq_len > max {
-            let instance_path = instance_path.cloned().unwrap_or(InstancePath::new());
-            raise_error(
-                format!(r#"{val} has more than {max} items"#),
-                &instance_path,
-            )?;
+            let path = instance_path.cloned().unwrap_or_else(InstancePath::new);
+            return Err(
+                SchemaError::new(format!(r#"{val} has more than {max} items"#), &path).into(),
+            );
         }
     }
     Ok(())
@@ -199,7 +197,7 @@ pub fn no_encoder_for_discriminator<K, D>(
     key: &K,
     discriminators: &[D],
     instance_path: &InstancePath,
-) -> PyErr
+) -> SerdeError
 where
     K: Display,
     D: Display,
@@ -209,54 +207,67 @@ where
         .map(|s| format!(r#""{s}""#))
         .collect::<Vec<_>>()
         .join(", ");
-    raise_error(
+    SchemaError::new(
         format!(r#""{key}" is not one of [{items}] discriminator values"#),
         instance_path,
     )
-    .unwrap_err()
+    .into()
 }
 
-pub fn _invalid_type_new(
+pub fn invalid_type_err(
     type_: &str,
     value: &Bound<'_, PyAny>,
     instance_path: &InstancePath,
-) -> PyResult<()> {
-    let error = format!(r#"{} is not of type "{}""#, fmt_py(value), type_);
-    raise_error(error, instance_path)?;
-    Ok(())
+) -> SerdeError {
+    SchemaError::new(
+        format!(r#"{} is not of type "{}""#, fmt_py(value), type_),
+        instance_path,
+    )
+    .into()
 }
 
 macro_rules! invalid_type {
-    ($type_: expr, $value: expr, $path: expr) => {{
-        crate::validator::validators::_invalid_type_new($type_, $value, $path)?;
-        unreachable!(); // todo: Discard the use of unreachable
-    }};
+    ($type_: expr, $value: expr, $path: expr) => {
+        return Err(crate::validator::validators::invalid_type_err(
+            $type_, $value, $path,
+        ))
+    };
+}
+
+pub fn invalid_type_dump_err(type_: &str, value: &Bound<'_, PyAny>) -> SerdeError {
+    SchemaError::new(
+        format!(r#""{}" is not of type "{}""#, value.to_string(), type_),
+        &InstancePath::new(),
+    )
+    .into()
 }
 
 macro_rules! invalid_type_dump {
-    ($type_: expr, $value: expr) => {{
-        let error = format!(r#""{}" is not of type "{}""#, $value.to_string(), $type_);
-        let instance_path = InstancePath::new();
-        crate::validator::raise_error(error, &instance_path)?;
-        unreachable!(); // todo: Discard the use of unreachable
-    }};
+    ($type_: expr, $value: expr) => {
+        return Err(crate::validator::validators::invalid_type_dump_err(
+            $type_, $value,
+        ))
+    };
 }
 
-pub fn _invalid_enum_item(
+pub fn invalid_enum_item_err(
     items: &str,
     value: &Bound<'_, PyAny>,
     instance_path: &InstancePath,
-) -> PyResult<()> {
-    let error = format!(r#"{} is not one of {}"#, fmt_py(value), items);
-    raise_error(error, instance_path)?;
-    Ok(())
+) -> SerdeError {
+    SchemaError::new(
+        format!(r#"{} is not one of {}"#, fmt_py(value), items),
+        instance_path,
+    )
+    .into()
 }
 
 macro_rules! invalid_enum_item {
-    ($items: expr, $value: expr, $path: expr) => {{
-        crate::validator::validators::_invalid_enum_item($items, $value, $path)?;
-        unreachable!(); // todo: Discard the use of unreachable
-    }};
+    ($items: expr, $value: expr, $path: expr) => {
+        return Err(crate::validator::validators::invalid_enum_item_err(
+            $items, $value, $path,
+        ))
+    };
 }
 
 pub fn str_as_bool(str: &str) -> Option<bool> {
@@ -267,7 +278,6 @@ pub fn str_as_bool(str: &str) -> Option<bool> {
     }
 }
 
-use crate::python::fmt_py;
 pub(crate) use check_bounds;
 pub(crate) use invalid_enum_item;
 pub(crate) use invalid_type;

--- a/src/validator/validators.rs
+++ b/src/validator/validators.rs
@@ -236,7 +236,7 @@ macro_rules! invalid_type {
 
 pub fn invalid_type_dump_err(type_: &str, value: &Bound<'_, PyAny>) -> SerdeError {
     SchemaError::new(
-        format!(r#""{}" is not of type "{}""#, value.to_string(), type_),
+        format!(r#""{value}" is not of type "{type_}""#),
         &InstancePath::new(),
     )
     .into()

--- a/tests/test_keyboard_interrupt_passthrough.py
+++ b/tests/test_keyboard_interrupt_passthrough.py
@@ -1,0 +1,48 @@
+"""Regression: BaseException-only errors (KeyboardInterrupt, SystemExit) from a custom
+encoder must propagate through Union without being swallowed."""
+
+from typing import Annotated, Union
+
+import pytest
+from serpyco_rs import SchemaValidationError, Serializer
+from serpyco_rs.metadata import CustomEncoder
+
+
+def test_keyboard_interrupt_from_custom_decoder_propagates_through_union():
+    def raise_keyboard_interrupt(value):
+        raise KeyboardInterrupt()
+
+    def identity(value):
+        return value
+
+    AnnotatedInt = Annotated[
+        int,
+        CustomEncoder[int, int](serialize=identity, deserialize=raise_keyboard_interrupt),
+    ]
+
+    serializer = Serializer(Union[AnnotatedInt, str])
+
+    with pytest.raises(KeyboardInterrupt):
+        serializer.load(42)
+
+
+def test_value_error_from_custom_decoder_is_caught_by_union():
+    """Counterpart: regular Exception subclasses MUST be swallowed by Union (retry)."""
+
+    def raise_value_error(value):
+        raise ValueError('nope')
+
+    def identity(value):
+        return value
+
+    AnnotatedInt = Annotated[
+        int,
+        CustomEncoder[int, int](serialize=identity, deserialize=raise_value_error),
+    ]
+
+    serializer = Serializer(Union[AnnotatedInt, str])
+
+    # int 42 makes the custom decoder raise ValueError → Union should fall through to str.
+    # But 42 isn't str either, so it should ultimately raise SchemaValidationError, not ValueError.
+    with pytest.raises(SchemaValidationError):
+        serializer.load(42)

--- a/tests/test_union_dump_regression.py
+++ b/tests/test_union_dump_regression.py
@@ -1,0 +1,18 @@
+import datetime
+from dataclasses import dataclass
+from typing import Union
+
+from serpyco_rs import Serializer
+
+
+def test_dump_union_time_or_date_picks_right_encoder():
+    @dataclass
+    class Foo:
+        val: Union[datetime.time, datetime.date]
+
+    s = Serializer(Foo)
+    result = s.dump(Foo(val=datetime.date(2024, 1, 1)))
+    assert result['val'] == '2024-01-01'
+
+    result = s.dump(Foo(val=datetime.time(10, 30)))
+    assert result['val'].startswith('10:30')


### PR DESCRIPTION
## Summary

- Introduce a Rust-internal `SerdeError { Schema, Py }` enum; convert to `PyErr` only at the FFI boundary (`Serializer::{load, dump, load_query_params}`).
- `UnionEncoder::load` / `::dump` distinguish `Schema(_)` (miss → try next variant, no `PyErr` allocated) from `Py(_)` (real Python error → propagate). Previously every miss constructed a full `SchemaValidationError`.
- `CustomEncoder` / `CustomTypeEncoder` route user-callback errors through `SerdeError::from_user_callback`: regular `Exception` subclasses become schema errors (with `cause`), but `BaseException`-only types (`KeyboardInterrupt`, `SystemExit`) propagate. This also fixes an existing bug where the old `UnionEncoder` swallowed `KeyboardInterrupt` via `result.is_ok()`.

## Benchmarks

`bench/test_encoders.py::test_load_union_miss_first` (new): `Union[Foo, int]` loaded with `42` — first variant misses.

|                          | master   | this branch | speedup |
|--------------------------|----------|-------------|---------|
| `test_load_union_miss_first` | 175.5 µs | 129.3 µs   | **1.36x** |
| `test_load_union` (sanity)   | 314.5 µs | 272.1 µs   | 1.16x   |