### PR TITLE
CI: pin actions to SHAs, add cargo audit, harden release perms

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,15 +34,15 @@ jobs:
     name: Build on ${{ matrix.os}} ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         id: python
         with:
           python-version: ${{ matrix.python-version-full || matrix.python-version }}
           allow-prereleases: true
           cache: "pip"
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: cache-uv
         with:
           path: ~/.cache/uv
@@ -50,11 +50,11 @@ jobs:
 
       - name: Install rust stable
         id: rust-toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: llvm-tools
 
-      - uses: PyO3/maturin-action@v1
+      - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           manylinux: auto
           target: ${{ matrix.target }}
@@ -89,7 +89,7 @@ jobs:
         run: ${{ env.LLVM_PROFDATA }} merge -o ${{ github.workspace }}/merged.profdata ${{ github.workspace }}/target/profdata
 
       - name: Build pgo-optimized wheel
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           manylinux: auto
           rust-toolchain: stable
@@ -105,7 +105,7 @@ jobs:
           RUSTFLAGS: "-Cprofile-use=${{ github.workspace }}/merged.profdata"
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: wheels_${{ matrix.os }}_${{ matrix.python-version }}
           path: dist
@@ -129,9 +129,9 @@ jobs:
             arch: ppc64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: "Build wheels"
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           target: ${{ matrix.platform.target }}
           manylinux: auto
@@ -139,7 +139,7 @@ jobs:
           args: --release --sdist -o dist --interpreter 3.10 3.11 3.12 3.13 3.14
           sccache: "true"
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: wheels_${{ matrix.platform.arch }}
           path: dist
@@ -155,13 +155,13 @@ jobs:
     name: Test on ${{ matrix.os}} ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: wheels_*
           merge-multiple: true
@@ -186,22 +186,26 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
+    # Skip on forked PRs — CODECOV_TOKEN is not exposed there.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - name: set up Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.13"
       - name: Install rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: llvm-tools-preview
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d # v2
+        with:
+          tool: cargo-llvm-cov
       - name: Install lcov
         run: sudo apt-get update && sudo apt-get install -y lcov
       - name: install dependencies
@@ -210,12 +214,12 @@ jobs:
       - name: coverage
         run: nox -s coverage
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage
           path: coverage
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: coverage/lcov.info
           fail_ci_if_error: false
@@ -230,12 +234,12 @@ jobs:
     name: Benchmark on ${{ matrix.os}}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: set up Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: 3.13
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: wheels_*
           merge-multiple: true
@@ -253,13 +257,13 @@ jobs:
     name: Test reference count leaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: deadsnakes/action@v3.1.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: deadsnakes/action@6c8b9b82fe0b4344f4b98f2775fcc395df45e494 # v3.1.0
         with:
           python-version: 3.13
           debug: true
       - run: python3.13 --version --version && which python3.13 && python3.13 -c "import sys; print(sys.gettotalrefcount())"
-      - uses: PyO3/maturin-action@v1
+      - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           command: build
           args: --release --sdist -o wheels
@@ -272,26 +276,28 @@ jobs:
 
   benchmark-codespeed:
     needs: [build]
+    # Skip on forked PRs — CODSPEED_TOKEN is not exposed there.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     strategy:
       fail-fast: false
       matrix:
         mode: [instrumentation, walltime]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: cache-uv
         with:
           path: ~/.cache/uv
           key: ubuntu-latest-python-3.13-uv-${{ matrix.mode }}
       - name: set up Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: 3.13
           cache: "pip"
           cache-dependency-path: |
             requirements/*.txt
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: wheels_*
           merge-multiple: true
@@ -301,7 +307,7 @@ jobs:
           python -m pip install --upgrade pip nox uv
           nox -s bench_codespeed --no-venv --install-only
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v3
+        uses: CodSpeedHQ/action@76578c2a7ddd928664caa737f0e962e3085d4e7c # v3
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: ${{ matrix.mode }}
@@ -313,12 +319,9 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt
       - run: cargo fmt --all -- --check
 
@@ -326,31 +329,38 @@ jobs:
     name: clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: clippy
       - run: cargo clippy --all-targets --all-features -- -D warnings
+
+  audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d # v2
+        with:
+          tool: cargo-audit
+      - run: cargo audit
 
   release:
     name: release
     runs-on: ubuntu-latest
     if: startsWith(github.event.ref, 'refs/tags')
     needs: [build, linux-cross, test]
-    permissions:
-      contents: read
+    permissions: {}
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: wheels_*
           merge-multiple: true
           path: dist
 
       - name: Publish to PyPI
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         with:


### PR DESCRIPTION
## Summary

Supply-chain hardening for the CI workflow.

- Pin every third-party action to a commit SHA (with a trailing `# vN` tag comment for readability). Affected: `actions/checkout`, `actions/setup-python`, `actions/cache`, `actions/download-artifact`, `actions/upload-artifact`, `dtolnay/rust-toolchain`, `PyO3/maturin-action`, `codecov/codecov-action`, `deadsnakes/action`, `taiki-e/install-action`, `CodSpeedHQ/action`.
- Drop the archived `actions-rs/toolchain@v1` (`fmt`/`clippy` jobs) in favour of pinned `dtolnay/rust-toolchain`.
- Bump `actions/setup-python` and `actions/checkout` to the latest majors uniformly (was a mix of v2/v3/v4 across jobs).
- Add a `cargo audit` job using `taiki-e/install-action`.
- Set `permissions: {}` on the `release` job — it only needs `MATURIN_PYPI_TOKEN` via env.
- Skip `coverage` and `benchmark-codespeed` on forked PRs where `CODECOV_TOKEN`/`CODSPEED_TOKEN` are not exposed.
- Enable Dependabot for the `github-actions` ecosystem so pinned SHAs get automatic update PRs.

No behavior change for trusted builds. `taiki-e/install-action` switched to `with: tool: cargo-llvm-cov` to match the SHA-pin format.