### PR TITLE
Refactor: Arc<dyn Encoder> in LazyEncoder, drop Encoders enum

### DIFF
--- a/src/serializer/encoders.rs
+++ b/src/serializer/encoders.rs
@@ -1079,37 +1079,22 @@ impl Encoder for DateEncoder {
     }
 }
 
-#[derive(Debug)]
-pub enum Encoders {
-    Entity(EntityEncoder),
-    TypedDict(TypedDictEncoder),
-    Dict(DictionaryEncoder),
-    Union(UnionEncoder),
-    DiscriminatedUnion(DiscriminatedUnionEncoder),
-    Tuple(TupleEncoder),
-    Array(ArrayEncoder),
-    Optional(OptionalEncoder),
-}
-
+/// Placeholder for a recursive encoder.
+///
+/// During `get_encoder` we eagerly build encoders for nested types; when a
+/// type references itself we hand out a `LazyEncoder` and back-fill the inner
+/// `Arc<dyn Encoder>` after the surrounding encoder is built. Dump/load is a
+/// single dynamic dispatch through the trait object, no per-variant match.
 #[derive(Debug, Clone)]
 pub struct LazyEncoder {
-    pub(crate) inner: Arc<AtomicRefCell<Option<Encoders>>>,
+    pub(crate) inner: Arc<AtomicRefCell<Option<Arc<TEncoder>>>>,
 }
 
 impl Encoder for LazyEncoder {
     #[inline]
     fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
         match self.inner.borrow().as_ref() {
-            Some(encoder) => match encoder {
-                Encoders::Entity(encoder) => encoder.dump(value),
-                Encoders::TypedDict(encoder) => encoder.dump(value),
-                Encoders::Union(encoder) => encoder.dump(value),
-                Encoders::DiscriminatedUnion(encoder) => encoder.dump(value),
-                Encoders::Tuple(encoder) => encoder.dump(value),
-                Encoders::Array(encoder) => encoder.dump(value),
-                Encoders::Optional(encoder) => encoder.dump(value),
-                Encoders::Dict(encoder) => encoder.dump(value),
-            },
+            Some(encoder) => encoder.dump(value),
             None => Err(SerdeError::Py(PyRuntimeError::new_err(
                 "[RUST] Invalid recursive encoder".to_string(),
             ))),
@@ -1124,16 +1109,7 @@ impl Encoder for LazyEncoder {
         ctx: &Context,
     ) -> SerdeResult<Bound<'a, PyAny>> {
         match self.inner.borrow().as_ref() {
-            Some(encoder) => match encoder {
-                Encoders::Entity(encoder) => encoder.load(value, instance_path, ctx),
-                Encoders::TypedDict(encoder) => encoder.load(value, instance_path, ctx),
-                Encoders::Tuple(encoder) => encoder.load(value, instance_path, ctx),
-                Encoders::Array(encoder) => encoder.load(value, instance_path, ctx),
-                Encoders::Optional(encoder) => encoder.load(value, instance_path, ctx),
-                Encoders::Union(encoder) => encoder.load(value, instance_path, ctx),
-                Encoders::DiscriminatedUnion(encoder) => encoder.load(value, instance_path, ctx),
-                Encoders::Dict(encoder) => encoder.load(value, instance_path, ctx),
-            },
+            Some(encoder) => encoder.load(value, instance_path, ctx),
             None => Err(SerdeError::Py(PyRuntimeError::new_err(
                 "[RUST] Invalid recursive encoder".to_string(),
             ))),

--- a/src/serializer/main.rs
+++ b/src/serializer/main.rs
@@ -21,8 +21,8 @@ use super::encoders::{
     NoopEncoder, OptionalEncoder, TupleEncoder, UUIDEncoder,
 };
 use super::encoders::{
-    CustomEncoder, DateEncoder, DateTimeEncoder, DiscriminatedUnionEncoder, Encoders, LazyEncoder,
-    TEncoder, TimeEncoder,
+    CustomEncoder, DateEncoder, DateTimeEncoder, DiscriminatedUnionEncoder, LazyEncoder, TEncoder,
+    TimeEncoder,
 };
 
 type CustomEncoderFns = (Option<Py<PyAny>>, Option<Py<PyAny>>);
@@ -206,13 +206,7 @@ pub fn get_encoder(
                 encoder: get_encoder(py, inner, encoder_state, naive_datetime_to_utc)?,
             };
 
-            encoder_state.create_and_register(
-                py,
-                encoder,
-                base_type,
-                python_object_id,
-                Encoders::Optional,
-            )?
+            encoder_state.create_and_register(py, encoder, base_type, python_object_id)?
         }
         Type::Dictionary(type_info, base_type, python_object_id) => {
             let key_type = get_object_type(type_info.key_type.bind(py))?;
@@ -227,13 +221,7 @@ pub fn get_encoder(
                 omit_none: type_info.omit_none,
             };
 
-            encoder_state.create_and_register(
-                py,
-                encoder,
-                base_type,
-                python_object_id,
-                Encoders::Dict,
-            )?
+            encoder_state.create_and_register(py, encoder, base_type, python_object_id)?
         }
         Type::Array(type_info, base_type, python_object_id) => {
             let item_type = get_object_type(type_info.item_type.bind(py))?;
@@ -245,13 +233,7 @@ pub fn get_encoder(
                 max_length: type_info.max_length,
             };
 
-            encoder_state.create_and_register(
-                py,
-                encoder,
-                base_type,
-                python_object_id,
-                Encoders::Array,
-            )?
+            encoder_state.create_and_register(py, encoder, base_type, python_object_id)?
         }
         Type::Tuple(type_info, base_type, python_object_id) => {
             let mut encoders = vec![];
@@ -268,13 +250,7 @@ pub fn get_encoder(
 
             let encoder = TupleEncoder { encoders };
 
-            encoder_state.create_and_register(
-                py,
-                encoder,
-                base_type,
-                python_object_id,
-                Encoders::Tuple,
-            )?
+            encoder_state.create_and_register(py, encoder, base_type, python_object_id)?
         }
         Type::Union(type_info, base_type, python_object_id) => {
             let item_types = type_info.item_types.bind(py).cast::<PyList>()?;
@@ -296,13 +272,7 @@ pub fn get_encoder(
                 repr: type_info.repr.clone(),
             };
 
-            encoder_state.create_and_register(
-                py,
-                encoder,
-                base_type,
-                python_object_id,
-                Encoders::Union,
-            )?
+            encoder_state.create_and_register(py, encoder, base_type, python_object_id)?
         }
         Type::DiscriminatedUnion(type_info, base_type, python_object_id) => {
             let dump_discriminator = type_info.dump_discriminator.bind(py).cast::<PyString>()?;
@@ -336,13 +306,7 @@ pub fn get_encoder(
                 keys,
             };
 
-            encoder_state.create_and_register(
-                py,
-                encoder,
-                base_type,
-                python_object_id,
-                Encoders::DiscriminatedUnion,
-            )?
+            encoder_state.create_and_register(py, encoder, base_type, python_object_id)?
         }
         Type::Entity(type_info, base_type, python_object_id) => {
             let fields =
@@ -363,13 +327,7 @@ pub fn get_encoder(
                 used_keys: type_info.used_keys.clone_ref(py),
             };
 
-            encoder_state.create_and_register(
-                py,
-                encoder,
-                base_type,
-                python_object_id,
-                Encoders::Entity,
-            )?
+            encoder_state.create_and_register(py, encoder, base_type, python_object_id)?
         }
         Type::TypedDict(type_info, base_type, python_object_id) => {
             let fields =
@@ -381,13 +339,7 @@ pub fn get_encoder(
                 used_keys: type_info.used_keys.clone_ref(py),
             };
 
-            encoder_state.create_and_register(
-                py,
-                encoder,
-                base_type,
-                python_object_id,
-                Encoders::TypedDict,
-            )?
+            encoder_state.create_and_register(py, encoder, base_type, python_object_id)?
         }
         Type::RecursionHolder(type_info, base_type) => {
             let encoder_ref = encoder_state.get_encoder_ref(type_info.inner_type_id);
@@ -500,7 +452,7 @@ fn iterate_on_fields(
     Ok(fields)
 }
 
-type EncoderStateValue = Arc<AtomicRefCell<Option<Encoders>>>;
+type EncoderStateValue = Arc<AtomicRefCell<Option<Arc<TEncoder>>>>;
 
 #[derive(Default)]
 pub struct EncoderState {
@@ -514,11 +466,6 @@ impl EncoderState {
         }
     }
 
-    fn register_encoder(&mut self, python_object_id: usize, encoder_variant: Encoders) {
-        let val = self.state.entry(python_object_id).or_default();
-        AtomicRefCell::<Option<Encoders>>::borrow_mut(val).replace(encoder_variant);
-    }
-
     pub fn get_encoder_ref(&mut self, python_object_id: usize) -> EncoderStateValue {
         self.state.entry(python_object_id).or_default().clone()
     }
@@ -529,12 +476,16 @@ impl EncoderState {
         encoder: T,
         base_type: BaseTypeInfo,
         python_object_id: usize,
-        encoder_variant_fn: impl FnOnce(T) -> Encoders,
     ) -> PyResult<Box<TEncoder>>
     where
         T: Clone + crate::serializer::encoders::Encoder + Send + Sync + 'static,
     {
-        self.register_encoder(python_object_id, encoder_variant_fn(encoder.clone()));
+        let shared: Arc<TEncoder> = Arc::new(encoder.clone());
+        self.state
+            .entry(python_object_id)
+            .or_default()
+            .borrow_mut()
+            .replace(shared);
         wrap_with_custom_encoder(py, base_type, Box::new(encoder))
     }
 }


### PR DESCRIPTION
## Summary

Removes the `Encoders` enum (third type registry used to back recursive references) and switches `LazyEncoder` to a plain `Arc<dyn Encoder>`.

Before:
- Recursive type → `Arc<AtomicRefCell<Option<Encoders>>>` where `Encoders` was an 8-variant enum (`Entity` / `TypedDict` / `Dict` / `Union` / `DiscriminatedUnion` / `Tuple` / `Array` / `Optional`).
- `LazyEncoder::dump` / `load` did `borrow()` + outer `match Option` + inner `match Encoders` (8 arms) on **every** call.
- Every new container-encoder variant required parallel edits in three places (the encoder struct, the `Encoders` enum, both `match` arms).

After:
- `EncoderStateValue = Arc<AtomicRefCell<Option<Arc<TEncoder>>>>` — a shared trait object.
- `LazyEncoder::dump` / `load` is a single dynamic dispatch through the trait object.
- `create_and_register` no longer takes an `encoder_variant_fn: impl FnOnce(T) -> Encoders` — it just wraps the cloned encoder in `Arc<TEncoder>`.

Net change: `-99 / +26` lines, fewer files to touch when adding a recursive container encoder, and one fewer `match` per recursive node on the hot path.

`dyn_clone` is still needed elsewhere (`Box<TEncoder>` is the primary ownership and is cloned via `clone_trait_object!`), so the `Encoder: DynClone` bound stays.

Verification:
- `cargo clippy --all-targets --all-features -- -D warnings` clean.
- `pytest tests/` — 414 passed.
- Local microbench: `github_issue` dump and recursive (depth 50) dump/load unchanged or slightly faster — CodSpeed instrumentation run on this PR will show the real numbers.