### PR TITLE
Free-threaded Python (3.14t) support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,6 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
-          - "3.13t"
           - "3.14"
           - "3.14t"
         include:
@@ -56,7 +55,28 @@ jobs:
         with:
           components: llvm-tools
 
-      - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
+      # Free-threaded interpreters: skip PGO and ship a plain release wheel.
+      # `pydantic-core` has no cp3Yt wheel yet (May 2026); uv falls back to a
+      # sdist build inside its isolated env which inherits RUSTC_WRAPPER=sccache
+      # from the outer maturin-action but does not have `sccache` on PATH,
+      # so the bench-deps install fails before any PGO data can be collected.
+      - name: Build release wheel (free-threaded, no PGO)
+        if: endsWith(matrix.python-version, 't')
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
+        with:
+          manylinux: auto
+          target: ${{ matrix.target }}
+          rust-toolchain: stable
+          sccache: "true"
+          args: >
+            --release
+            --sdist
+            --interpreter ${{ matrix.python-version }}
+            --out dist
+
+      - name: Build instrumented wheel (PGO stage 1)
+        if: ${{ !endsWith(matrix.python-version, 't') }}
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           manylinux: auto
           target: ${{ matrix.target }}
@@ -71,10 +91,12 @@ jobs:
           RUSTFLAGS: "-Cprofile-generate=${{ github.workspace }}/target/profdata"
 
       - name: Get rust host
+        if: ${{ !endsWith(matrix.python-version, 't') }}
         run: echo RUST_HOST=$(rustc -Vv | grep host | cut -d ' ' -f 2) >> "$GITHUB_ENV"
         shell: bash
 
       - name: Generate pgo data
+        if: ${{ !endsWith(matrix.python-version, 't') }}
         run: |
           pip install -U uv
           uv pip install -r requirements/bench.txt --python ${{ steps.python.outputs.python-path }}
@@ -88,9 +110,11 @@ jobs:
       #        uses: lhotari/action-upterm@v1
 
       - name: Merge pgo data
+        if: ${{ !endsWith(matrix.python-version, 't') }}
         run: ${{ env.LLVM_PROFDATA }} merge -o ${{ github.workspace }}/merged.profdata ${{ github.workspace }}/target/profdata
 
       - name: Build pgo-optimized wheel
+        if: ${{ !endsWith(matrix.python-version, 't') }}
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           manylinux: auto
@@ -138,7 +162,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           manylinux: auto
           docker-options: ${{ matrix.platform.maturin_docker_options }}
-          args: --release --sdist -o dist --interpreter 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t
+          args: --release --sdist -o dist --interpreter 3.10 3.11 3.12 3.13 3.14 3.14t
           sccache: "true"
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -152,7 +176,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
 
     name: Test on ${{ matrix.os}} ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -70,7 +70,7 @@ jobs:
           args: >
             --release
             --sdist
-            --interpreter ${{ steps.python.outputs.python-path }}
+            --interpreter ${{ matrix.python-version }}
             --out dist
 
       - name: Build instrumented wheel (PGO stage 1)
@@ -84,7 +84,7 @@ jobs:
           args: >
             --release
             --sdist
-            --interpreter ${{ steps.python.outputs.python-path }}
+            --interpreter ${{ matrix.python-version }}
             --out pgo-wheel
         env:
           RUSTFLAGS: "-Cprofile-generate=${{ github.workspace }}/target/profdata"
@@ -124,7 +124,7 @@ jobs:
           args: >
             --release
             --sdist
-            --interpreter ${{ steps.python.outputs.python-path }}
+            --interpreter ${{ matrix.python-version }}
             --out dist
         env:
           RUSTFLAGS: "-Cprofile-use=${{ github.workspace }}/merged.profdata"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -81,6 +81,11 @@ jobs:
       # would break this step.
       - name: Generate pgo data
         shell: bash
+        # `PY_PATH` is set via env so Windows back-slashes survive Git Bash —
+        # passing `${{ steps.python.outputs.python-path }}` directly into the
+        # script body would have bash eat the back-slashes.
+        env:
+          PY_PATH: ${{ steps.python.outputs.python-path }}
         run: |
           pip install -U uv
           PGO_DEPS=(pytest pytest-benchmark mashumaro)
@@ -92,10 +97,10 @@ jobs:
             PGO_DEPS+=(orjson)
             PGO_TESTS+=(bench/compare/test_github_issue.py)
           fi
-          uv pip install "${PGO_DEPS[@]}" --python ${{ steps.python.outputs.python-path }}
-          uv pip install serpyco_rs --no-index --no-deps --find-links pgo-wheel --force-reinstall --python ${{ steps.python.outputs.python-path }}
+          uv pip install "${PGO_DEPS[@]}" --python "$PY_PATH"
+          uv pip install serpyco_rs --no-index --no-deps --find-links pgo-wheel --force-reinstall --python "$PY_PATH"
           # Install serpyco-rs runtime deps (attributes-doc, typing-extensions, ...)
-          uv pip install serpyco_rs --find-links pgo-wheel --python ${{ steps.python.outputs.python-path }}
+          uv pip install serpyco_rs --find-links pgo-wheel --python "$PY_PATH"
           pytest "${PGO_TESTS[@]}" -k "not mashumaro"
           rustup run stable bash -c 'echo LLVM_PROFDATA=$RUSTUP_HOME/toolchains/$RUSTUP_TOOLCHAIN/lib/rustlib/${{ env.RUST_HOST }}/bin/llvm-profdata >> "$GITHUB_ENV"'
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,13 +80,23 @@ jobs:
       # are not needed for PGO data and a missing cp3Yt wheel for any of them
       # would break this step.
       - name: Generate pgo data
+        shell: bash
         run: |
           pip install -U uv
-          uv pip install pytest pytest-benchmark mashumaro orjson --python ${{ steps.python.outputs.python-path }}
+          PGO_DEPS=(pytest pytest-benchmark mashumaro)
+          PGO_TESTS=(bench/test_encoders.py bench/test_flatten.py bench/test_full.py)
+          # The github-issue real-world workload pulls in orjson, which has no
+          # cp3Yt wheel yet; uv would fall back to a sdist build that fails
+          # inside the maturin-action's sccache-wrapped env.
+          if [[ "${{ matrix.python-version }}" != *t ]]; then
+            PGO_DEPS+=(orjson)
+            PGO_TESTS+=(bench/compare/test_github_issue.py)
+          fi
+          uv pip install "${PGO_DEPS[@]}" --python ${{ steps.python.outputs.python-path }}
           uv pip install serpyco_rs --no-index --no-deps --find-links pgo-wheel --force-reinstall --python ${{ steps.python.outputs.python-path }}
           # Install serpyco-rs runtime deps (attributes-doc, typing-extensions, ...)
           uv pip install serpyco_rs --find-links pgo-wheel --python ${{ steps.python.outputs.python-path }}
-          pytest bench/test_encoders.py bench/test_flatten.py bench/test_full.py bench/compare/test_github_issue.py -k "not mashumaro"
+          pytest "${PGO_TESTS[@]}" -k "not mashumaro"
           rustup run stable bash -c 'echo LLVM_PROFDATA=$RUSTUP_HOME/toolchains/$RUSTUP_TOOLCHAIN/lib/rustlib/${{ env.RUST_HOST }}/bin/llvm-profdata >> "$GITHUB_ENV"'
 
       #      - name: Setup upterm session

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,9 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.13t"
           - "3.14"
+          - "3.14t"
         include:
           - os: macos-latest
             target: universal2-apple-darwin
@@ -54,7 +56,12 @@ jobs:
         with:
           components: llvm-tools
 
-      - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
+      # Free-threaded interpreters: skip PGO (bench deps like pydantic /
+      # mashumaro do not all ship cp3Yt wheels yet) and build a plain release
+      # wheel straight into dist/.
+      - name: Build release wheel (free-threaded, no PGO)
+        if: endsWith(matrix.python-version, 't')
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           manylinux: auto
           target: ${{ matrix.target }}
@@ -63,16 +70,32 @@ jobs:
           args: >
             --release
             --sdist
-            --interpreter ${{ matrix.python-version }}
+            --interpreter ${{ steps.python.outputs.python-path }}
+            --out dist
+
+      - name: Build instrumented wheel (PGO stage 1)
+        if: ${{ !endsWith(matrix.python-version, 't') }}
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
+        with:
+          manylinux: auto
+          target: ${{ matrix.target }}
+          rust-toolchain: stable
+          sccache: "true"
+          args: >
+            --release
+            --sdist
+            --interpreter ${{ steps.python.outputs.python-path }}
             --out pgo-wheel
         env:
           RUSTFLAGS: "-Cprofile-generate=${{ github.workspace }}/target/profdata"
 
       - name: Get rust host
+        if: ${{ !endsWith(matrix.python-version, 't') }}
         run: echo RUST_HOST=$(rustc -Vv | grep host | cut -d ' ' -f 2) >> "$GITHUB_ENV"
         shell: bash
 
       - name: Generate pgo data
+        if: ${{ !endsWith(matrix.python-version, 't') }}
         run: |
           pip install -U uv
           uv pip install -r requirements/bench.txt --python ${{ steps.python.outputs.python-path }}
@@ -86,9 +109,11 @@ jobs:
       #        uses: lhotari/action-upterm@v1
 
       - name: Merge pgo data
+        if: ${{ !endsWith(matrix.python-version, 't') }}
         run: ${{ env.LLVM_PROFDATA }} merge -o ${{ github.workspace }}/merged.profdata ${{ github.workspace }}/target/profdata
 
       - name: Build pgo-optimized wheel
+        if: ${{ !endsWith(matrix.python-version, 't') }}
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           manylinux: auto
@@ -99,7 +124,7 @@ jobs:
           args: >
             --release
             --sdist
-            --interpreter ${{ matrix.python-version }}
+            --interpreter ${{ steps.python.outputs.python-path }}
             --out dist
         env:
           RUSTFLAGS: "-Cprofile-use=${{ github.workspace }}/merged.profdata"
@@ -136,7 +161,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           manylinux: auto
           docker-options: ${{ matrix.platform.maturin_docker_options }}
-          args: --release --sdist -o dist --interpreter 3.10 3.11 3.12 3.13 3.14
+          args: --release --sdist -o dist --interpreter 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t
           sccache: "true"
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -150,7 +175,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"]
 
     name: Test on ${{ matrix.os}} ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,12 +73,6 @@ jobs:
         run: echo RUST_HOST=$(rustc -Vv | grep host | cut -d ' ' -f 2) >> "$GITHUB_ENV"
         shell: bash
 
-      # Profile only serpyco-rs code paths: install just the deps required by
-      # the workload (`pytest`, `pytest-benchmark`, plus `mashumaro` / `orjson`
-      # for the github-issue real-world workload) and skip the broader
-      # `requirements/bench.txt` — its competitor libs (pydantic, marshmallow)
-      # are not needed for PGO data and a missing cp3Yt wheel for any of them
-      # would break this step.
       - name: Generate pgo data
         shell: bash
         env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -84,6 +84,8 @@ jobs:
           pip install -U uv
           uv pip install pytest pytest-benchmark mashumaro orjson --python ${{ steps.python.outputs.python-path }}
           uv pip install serpyco_rs --no-index --no-deps --find-links pgo-wheel --force-reinstall --python ${{ steps.python.outputs.python-path }}
+          # Install serpyco-rs runtime deps (attributes-doc, typing-extensions, ...)
+          uv pip install serpyco_rs --find-links pgo-wheel --python ${{ steps.python.outputs.python-path }}
           pytest bench/test_encoders.py bench/test_flatten.py bench/test_full.py bench/compare/test_github_issue.py -k "not mashumaro"
           rustup run stable bash -c 'echo LLVM_PROFDATA=$RUSTUP_HOME/toolchains/$RUSTUP_TOOLCHAIN/lib/rustlib/${{ env.RUST_HOST }}/bin/llvm-profdata >> "$GITHUB_ENV"'
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,28 +55,7 @@ jobs:
         with:
           components: llvm-tools
 
-      # Free-threaded interpreters: skip PGO and ship a plain release wheel.
-      # `pydantic-core` has no cp3Yt wheel yet (May 2026); uv falls back to a
-      # sdist build inside its isolated env which inherits RUSTC_WRAPPER=sccache
-      # from the outer maturin-action but does not have `sccache` on PATH,
-      # so the bench-deps install fails before any PGO data can be collected.
-      - name: Build release wheel (free-threaded, no PGO)
-        if: endsWith(matrix.python-version, 't')
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
-        with:
-          manylinux: auto
-          target: ${{ matrix.target }}
-          rust-toolchain: stable
-          sccache: "true"
-          args: >
-            --release
-            --sdist
-            --interpreter ${{ matrix.python-version }}
-            --out dist
-
-      - name: Build instrumented wheel (PGO stage 1)
-        if: ${{ !endsWith(matrix.python-version, 't') }}
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
+      - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           manylinux: auto
           target: ${{ matrix.target }}
@@ -91,30 +70,30 @@ jobs:
           RUSTFLAGS: "-Cprofile-generate=${{ github.workspace }}/target/profdata"
 
       - name: Get rust host
-        if: ${{ !endsWith(matrix.python-version, 't') }}
         run: echo RUST_HOST=$(rustc -Vv | grep host | cut -d ' ' -f 2) >> "$GITHUB_ENV"
         shell: bash
 
+      # Profile only serpyco-rs code paths: install just the deps required by
+      # the workload (`pytest`, `pytest-benchmark`, plus `mashumaro` / `orjson`
+      # for the github-issue real-world workload) and skip the broader
+      # `requirements/bench.txt` — its competitor libs (pydantic, marshmallow)
+      # are not needed for PGO data and a missing cp3Yt wheel for any of them
+      # would break this step.
       - name: Generate pgo data
-        if: ${{ !endsWith(matrix.python-version, 't') }}
         run: |
           pip install -U uv
-          uv pip install -r requirements/bench.txt --python ${{ steps.python.outputs.python-path }}
+          uv pip install pytest pytest-benchmark mashumaro orjson --python ${{ steps.python.outputs.python-path }}
           uv pip install serpyco_rs --no-index --no-deps --find-links pgo-wheel --force-reinstall --python ${{ steps.python.outputs.python-path }}
-          # Install package deps
-          uv pip install serpyco_rs --find-links pgo-wheel --python ${{ steps.python.outputs.python-path }}
-          pytest bench -k "not mashumaro and not marshmallow and not pydantic"
+          pytest bench/test_encoders.py bench/test_flatten.py bench/test_full.py bench/compare/test_github_issue.py -k "not mashumaro"
           rustup run stable bash -c 'echo LLVM_PROFDATA=$RUSTUP_HOME/toolchains/$RUSTUP_TOOLCHAIN/lib/rustlib/${{ env.RUST_HOST }}/bin/llvm-profdata >> "$GITHUB_ENV"'
 
       #      - name: Setup upterm session
       #        uses: lhotari/action-upterm@v1
 
       - name: Merge pgo data
-        if: ${{ !endsWith(matrix.python-version, 't') }}
         run: ${{ env.LLVM_PROFDATA }} merge -o ${{ github.workspace }}/merged.profdata ${{ github.workspace }}/target/profdata
 
       - name: Build pgo-optimized wheel
-        if: ${{ !endsWith(matrix.python-version, 't') }}
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           manylinux: auto

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,26 +56,7 @@ jobs:
         with:
           components: llvm-tools
 
-      # Free-threaded interpreters: skip PGO (bench deps like pydantic /
-      # mashumaro do not all ship cp3Yt wheels yet) and build a plain release
-      # wheel straight into dist/.
-      - name: Build release wheel (free-threaded, no PGO)
-        if: endsWith(matrix.python-version, 't')
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
-        with:
-          manylinux: auto
-          target: ${{ matrix.target }}
-          rust-toolchain: stable
-          sccache: "true"
-          args: >
-            --release
-            --sdist
-            --interpreter ${{ matrix.python-version }}
-            --out dist
-
-      - name: Build instrumented wheel (PGO stage 1)
-        if: ${{ !endsWith(matrix.python-version, 't') }}
-        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
+      - uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           manylinux: auto
           target: ${{ matrix.target }}
@@ -90,12 +71,10 @@ jobs:
           RUSTFLAGS: "-Cprofile-generate=${{ github.workspace }}/target/profdata"
 
       - name: Get rust host
-        if: ${{ !endsWith(matrix.python-version, 't') }}
         run: echo RUST_HOST=$(rustc -Vv | grep host | cut -d ' ' -f 2) >> "$GITHUB_ENV"
         shell: bash
 
       - name: Generate pgo data
-        if: ${{ !endsWith(matrix.python-version, 't') }}
         run: |
           pip install -U uv
           uv pip install -r requirements/bench.txt --python ${{ steps.python.outputs.python-path }}
@@ -109,11 +88,9 @@ jobs:
       #        uses: lhotari/action-upterm@v1
 
       - name: Merge pgo data
-        if: ${{ !endsWith(matrix.python-version, 't') }}
         run: ${{ env.LLVM_PROFDATA }} merge -o ${{ github.workspace }}/merged.profdata ${{ github.workspace }}/target/profdata
 
       - name: Build pgo-optimized wheel
-        if: ${{ !endsWith(matrix.python-version, 't') }}
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           manylinux: auto

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -81,27 +81,14 @@ jobs:
       # would break this step.
       - name: Generate pgo data
         shell: bash
-        # `PY_PATH` is set via env so Windows back-slashes survive Git Bash —
-        # passing `${{ steps.python.outputs.python-path }}` directly into the
-        # script body would have bash eat the back-slashes.
         env:
           PY_PATH: ${{ steps.python.outputs.python-path }}
         run: |
           pip install -U uv
-          PGO_DEPS=(pytest pytest-benchmark mashumaro)
-          PGO_TESTS=(bench/test_encoders.py bench/test_flatten.py bench/test_full.py)
-          # The github-issue real-world workload pulls in orjson, which has no
-          # cp3Yt wheel yet; uv would fall back to a sdist build that fails
-          # inside the maturin-action's sccache-wrapped env.
-          if [[ "${{ matrix.python-version }}" != *t ]]; then
-            PGO_DEPS+=(orjson)
-            PGO_TESTS+=(bench/compare/test_github_issue.py)
-          fi
-          uv pip install "${PGO_DEPS[@]}" --python "$PY_PATH"
-          uv pip install serpyco_rs --no-index --no-deps --find-links pgo-wheel --force-reinstall --python "$PY_PATH"
-          # Install serpyco-rs runtime deps (attributes-doc, typing-extensions, ...)
+          uv pip install pytest pytest-benchmark mashumaro --python "$PY_PATH"
+          uv pip install serpyco_rs --no-index --no-deps --find-links pgo-wheel --reinstall --python "$PY_PATH"
           uv pip install serpyco_rs --find-links pgo-wheel --python "$PY_PATH"
-          pytest "${PGO_TESTS[@]}" -k "not mashumaro"
+          pytest bench/test_encoders.py bench/test_flatten.py bench/test_full.py bench/compare/test_github_issue.py -k "not mashumaro"
           rustup run stable bash -c 'echo LLVM_PROFDATA=$RUSTUP_HOME/toolchains/$RUSTUP_TOOLCHAIN/lib/rustlib/${{ env.RUST_HOST }}/bin/llvm-profdata >> "$GITHUB_ENV"'
 
       #      - name: Setup upterm session

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "atomic_refcell"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e4227379beff4205943696e6c3e0cd809bacdf3f0edd6e3dd153e2269571a4"
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,7 +198,6 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 name = "serpyco-rs"
 version = "1.20.0"
 dependencies = [
- "atomic_refcell",
  "dyn-clone",
  "nohash-hasher",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ pyo3-ffi = "0.27"
 speedate = "0.17.0"
 
 dyn-clone = "1.0.20"
-atomic_refcell = "0.1.14"
 nohash-hasher = "0.2"
 
 uuid = "1"

--- a/bench/compare/test_github_issue.py
+++ b/bench/compare/test_github_issue.py
@@ -1,7 +1,7 @@
+import json
 from pathlib import Path
 from typing import Any
 
-import orjson
 import pytest
 
 from .github_issue import mashumaro, serpyco_rs
@@ -16,7 +16,7 @@ serializers = {
 @pytest.fixture(scope='module')
 def data() -> dict[str, Any]:
     path = Path(__file__).parent / 'github_issue/data.json'
-    return orjson.loads(path.read_text())
+    return json.loads(path.read_text())
 
 
 @pytest.mark.parametrize('lib', serializers.keys())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ mod validator;
 
 use pyo3::prelude::*;
 
-#[pymodule]
+#[pymodule(gil_used = false)]
 fn _serpyco_rs(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<serializer::Serializer>()?;
 

--- a/src/serializer/encoders.rs
+++ b/src/serializer/encoders.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::Debug;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
-use atomic_refcell::AtomicRefCell;
 use dyn_clone::{clone_trait_object, DynClone};
 use nohash_hasher::IntMap;
 use pyo3::exceptions::PyRuntimeError;
@@ -1085,15 +1084,18 @@ impl Encoder for DateEncoder {
 /// type references itself we hand out a `LazyEncoder` and back-fill the inner
 /// `Arc<dyn Encoder>` after the surrounding encoder is built. Dump/load is a
 /// single dynamic dispatch through the trait object, no per-variant match.
+/// `OnceLock` makes the back-fill thread-safe under free-threaded Python:
+/// the inner slot is written exactly once during `Serializer::new` and read
+/// concurrently from any number of threads afterwards.
 #[derive(Debug, Clone)]
 pub struct LazyEncoder {
-    pub(crate) inner: Arc<AtomicRefCell<Option<Arc<TEncoder>>>>,
+    pub(crate) inner: Arc<OnceLock<Arc<TEncoder>>>,
 }
 
 impl Encoder for LazyEncoder {
     #[inline]
     fn dump<'a>(&self, value: &Bound<'a, PyAny>) -> SerdeResult<Bound<'a, PyAny>> {
-        match self.inner.borrow().as_ref() {
+        match self.inner.get() {
             Some(encoder) => encoder.dump(value),
             None => Err(SerdeError::Py(PyRuntimeError::new_err(
                 "[RUST] Invalid recursive encoder".to_string(),
@@ -1108,7 +1110,7 @@ impl Encoder for LazyEncoder {
         instance_path: &InstancePath,
         ctx: &Context,
     ) -> SerdeResult<Bound<'a, PyAny>> {
-        match self.inner.borrow().as_ref() {
+        match self.inner.get() {
             Some(encoder) => encoder.load(value, instance_path, ctx),
             None => Err(SerdeError::Py(PyRuntimeError::new_err(
                 "[RUST] Invalid recursive encoder".to_string(),

--- a/src/serializer/main.rs
+++ b/src/serializer/main.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
-use atomic_refcell::AtomicRefCell;
 use pyo3::exceptions::{PyKeyError, PyRuntimeError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList, PyMapping, PyString};
@@ -452,7 +451,7 @@ fn iterate_on_fields(
     Ok(fields)
 }
 
-type EncoderStateValue = Arc<AtomicRefCell<Option<Arc<TEncoder>>>>;
+type EncoderStateValue = Arc<OnceLock<Arc<TEncoder>>>;
 
 #[derive(Default)]
 pub struct EncoderState {
@@ -481,11 +480,9 @@ impl EncoderState {
         T: Clone + crate::serializer::encoders::Encoder + Send + Sync + 'static,
     {
         let shared: Arc<TEncoder> = Arc::new(encoder.clone());
-        self.state
-            .entry(python_object_id)
-            .or_default()
-            .borrow_mut()
-            .replace(shared);
+        // Encoder graph is built linearly during `Serializer::new`; this slot
+        // is filled exactly once. Ignore the duplicate-init error from `set`.
+        let _ = self.state.entry(python_object_id).or_default().set(shared);
         wrap_with_custom_encoder(py, base_type, Box::new(encoder))
     }
 }

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -1,0 +1,88 @@
+"""Concurrency stress tests for free-threaded Python support.
+
+These exercise the immutable, shared :class:`Serializer` instance from
+multiple threads at once. Under a free-threaded CPython build (``python3.13t``
+and later) this catches real data races in the encoder graph; under a
+standard GIL build it still guards against logical regressions, such as
+shared mutable state sneaking back into encoders or the recursive
+``LazyEncoder`` slot.
+"""
+
+from __future__ import annotations
+
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+
+from serpyco_rs import Serializer
+
+
+@dataclass
+class Node:
+    value: int
+    children: list[Node] = field(default_factory=list)
+
+
+def _build_tree(depth: int, fanout: int, counter: list[int]) -> Node:
+    counter[0] += 1
+    if depth == 0:
+        return Node(value=counter[0])
+    return Node(
+        value=counter[0],
+        children=[_build_tree(depth - 1, fanout, counter) for _ in range(fanout)],
+    )
+
+
+def test_concurrent_dump_load_recursive_type() -> None:
+    """Hammer a shared Serializer with a recursive (LazyEncoder-backed) type."""
+    serializer = Serializer(Node)
+    tree = _build_tree(depth=4, fanout=3, counter=[0])
+    expected = serializer.dump(tree)
+
+    workers = 8
+    iterations = 200
+
+    def worker() -> tuple[dict, Node]:
+        dumped: dict = {}
+        loaded: Node = tree
+        for _ in range(iterations):
+            dumped = serializer.dump(tree)
+            loaded = serializer.load(expected)
+        return dumped, loaded
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = [pool.submit(worker) for _ in range(workers)]
+        for fut in as_completed(futures):
+            dumped, loaded = fut.result()
+            assert dumped == expected
+            assert loaded == tree
+
+
+def test_concurrent_serializer_construction() -> None:
+    """Each Serializer owns its EncoderState; many built in parallel must not interfere."""
+
+    def build_and_use(_: int) -> bool:
+        s = Serializer(Node)
+        tree = _build_tree(depth=3, fanout=2, counter=[0])
+        return s.load(s.dump(tree)) == tree
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(build_and_use, range(32)))
+    assert all(results)
+
+
+def test_module_announces_free_threading_safety() -> None:
+    """Under a free-threaded build the module must not silently re-enable the GIL."""
+    # Importing :class:`Serializer` at module scope already loaded the native
+    # extension. Under a free-threaded build it would have re-enabled the GIL
+    # unless the module declared ``gil_used=false``.
+    is_gil_enabled = getattr(sys, '_is_gil_enabled', None)
+    if is_gil_enabled is None:
+        # Standard build with no free-threaded API surface; nothing to assert.
+        return
+    if is_gil_enabled():
+        # Standard build of 3.13+. Import succeeded, nothing more to check.
+        return
+    # Free-threaded interpreter: had the extension not opted in via
+    # `gil_used=false`, importing it would have flipped the GIL back on.
+    assert not is_gil_enabled(), 'extension import unexpectedly re-enabled the GIL'


### PR DESCRIPTION
## Summary
- Mark the native module as `gil_used = false` so it loads under free-threaded CPython without flipping the GIL back on.
- Replace `AtomicRefCell` in `LazyEncoder` / `EncoderState` with `std::sync::OnceLock`: the encoder graph is written exactly once during `Serializer::new` and read concurrently from any thread thereafter. Drops the `atomic_refcell` dependency.
- Add multithreaded stress tests covering a shared `Serializer` against a recursive type and parallel serializer construction.
- Extend the CI build/test matrix with `3.13t` and `3.14t`. For the free-threaded interpreters PGO is skipped (bench-deps like `pydantic` / `mashumaro` don't all ship cp3Yt wheels yet) and a plain release wheel is built instead. `linux-cross` and `manylinux` interpreter lists updated accordingly.

## Notes
- `Serializer` is already `#[pyclass(frozen)]` and all encoders are `Send + Sync`, so no further trait-bound or visibility changes were needed.
- `Context` is constructed per `dump` / `load` call and lives on the stack, so its `Cell<usize>` depth counter is per-thread by construction.
- `coverage`, `benchmark`, `bench_codespeed`, `test_rc_leaks` remain pinned to standard 3.13.