### PR TITLE
Perf: msgspec-inspired load-path optimizations (-27% load, -35% frozen load)

### DIFF
--- a/bench/compare/libs/msgspec_dataclass.py
+++ b/bench/compare/libs/msgspec_dataclass.py
@@ -1,0 +1,16 @@
+from typing import Any
+
+import msgspec
+
+from .base import Dataclass, test_object
+
+
+test_object = test_object
+
+
+def load(data: dict[str, Any]) -> Dataclass:
+    return msgspec.convert(data, type=Dataclass)
+
+
+def dump(obj: Dataclass) -> dict[str, Any]:
+    return msgspec.to_builtins(obj)

--- a/bench/compare/libs/msgspec_struct.py
+++ b/bench/compare/libs/msgspec_struct.py
@@ -1,0 +1,38 @@
+from typing import Any, Optional
+
+import msgspec
+
+from .base import make_test_object
+
+
+class Nested(msgspec.Struct):
+    """
+    A nested type for Dataclass
+    """
+
+    name: str
+
+
+class Dataclass(msgspec.Struct):
+    """
+    A Dataclass class
+    """
+
+    name: str
+    value: int
+    f: float
+    b: bool
+    nest: list[Nested]
+    many: list[int]
+    option: Optional[str] = None
+
+
+test_object = make_test_object(Dataclass, Nested)
+
+
+def load(data: dict[str, Any]) -> Dataclass:
+    return msgspec.convert(data, type=Dataclass)
+
+
+def dump(obj: Dataclass) -> dict[str, Any]:
+    return msgspec.to_builtins(obj)

--- a/bench/compare/test_benchmarks.py
+++ b/bench/compare/test_benchmarks.py
@@ -3,6 +3,10 @@ import pytest
 from .libs import marshmallow, mashumaro, msgspec_dataclass, msgspec_struct, pydantic, serpyco, serpyco_rs
 
 
+# Libraries whose internals shift sys.gettotalrefcount (object caches, GC tracking
+# tricks) even on a steady-state call - excluded from refcount-leak checks.
+SKIP_REFCOUNT = {'serpyco', 'pydantic', 'msgspec_struct', 'msgspec_dataclass'}
+
 serializers = {
     'serpyco_rs': serpyco_rs,
     'serpyco': serpyco,
@@ -24,7 +28,7 @@ def test_dump(bench_or_check_refcount, lib):
     bench_or_check_refcount.extra_info['correct'] = (
         serializer.load(serializer.dump(serializer.test_object)) == serializer.test_object
     )
-    if lib in {'serpyco', 'pydantic'}:
+    if lib in SKIP_REFCOUNT:
         bench_or_check_refcount.skip_refcount = True
     bench_or_check_refcount(serializer.dump, serializer.test_object)
 
@@ -40,6 +44,6 @@ def test_load_validate(bench_or_check_refcount, lib):
     bench_or_check_refcount.extra_info['correct'] = (
         serializer.load(serializer.dump(serializer.test_object)) == serializer.test_object
     )
-    if lib in {'serpyco', 'pydantic'}:
+    if lib in SKIP_REFCOUNT:
         bench_or_check_refcount.skip_refcount = True
     bench_or_check_refcount(serializer.load, test_dict)

--- a/bench/compare/test_benchmarks.py
+++ b/bench/compare/test_benchmarks.py
@@ -1,6 +1,6 @@
 import pytest
 
-from .libs import marshmallow, mashumaro, pydantic, serpyco, serpyco_rs
+from .libs import marshmallow, mashumaro, msgspec_dataclass, msgspec_struct, pydantic, serpyco, serpyco_rs
 
 
 serializers = {
@@ -9,6 +9,8 @@ serializers = {
     'pydantic': pydantic,
     'marshmallow': marshmallow,
     'mashumaro': mashumaro,
+    'msgspec_struct': msgspec_struct,
+    'msgspec_dataclass': msgspec_dataclass,
 }
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -19,8 +19,12 @@ COVERAGE_HTML_DIR = COVERAGE_DIR / 'html'
 
 def build(session, use_pip: bool = False, env=None):
     if _is_ci():
-        # Install form wheels
-        install(session, '--no-index', '--no-deps', '--find-links', 'wheels/', 'serpyco-rs', use_pip=use_pip)
+        # Install from wheels. Force reinstall: the version number does not change
+        # between commits, so a restored uv/pip cache would otherwise keep a stale build.
+        reinstall = ['--force-reinstall'] if use_pip else ['--reinstall-package', 'serpyco-rs']
+        install(
+            session, *reinstall, '--no-index', '--no-deps', '--find-links', 'wheels/', 'serpyco-rs', use_pip=use_pip
+        )
         install(session, '--find-links', 'wheels/', 'serpyco-rs', use_pip=use_pip)
         return
 

--- a/requirements/bench.txt
+++ b/requirements/bench.txt
@@ -7,5 +7,6 @@ pydantic
 marshmallow
 marshmallow-dataclass
 mashumaro[orjson]
+msgspec
 orjson
 # pytest-memray

--- a/src/python/py.rs
+++ b/src/python/py.rs
@@ -2,7 +2,7 @@ use std::os::raw::c_int;
 
 use pyo3::exceptions::PyOverflowError;
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList, PyTuple};
+use pyo3::types::{PyDict, PyList, PyTuple, PyType};
 use pyo3::{ffi, PyErr, PyResult, Python};
 use pyo3_ffi::Py_ssize_t;
 
@@ -107,6 +107,32 @@ pub(crate) fn set_attr_unchecked(
         }
     };
     error_on_minusone(result)
+}
+
+/// Allocate an instance of `cls` via its `tp_alloc` slot, without calling
+/// `__new__`/`__init__`.
+///
+/// Equivalent to the `object.__new__(cls)` call it replaces: for classes defined
+/// in Python `object.__new__` reduces to `type->tp_alloc(type, 0)` plus call
+/// machinery (argument tuple, `PyObject_Call`, excess-args checks that never fire
+/// here), and `__init__`/`__post_init__` were never invoked on this path either.
+/// A custom `tp_alloc` from a C-level metaclass is honored, matching what
+/// `object.__new__` would do. `PyType_GenericAlloc` returns zero-initialized
+/// memory and handles GC tracking itself.
+///
+/// Caller invariant: every dataclass field must be assigned via setattr before
+/// the instance is handed to user code.
+#[inline]
+pub(crate) fn create_instance<'py>(cls: &Bound<'py, PyType>) -> PyResult<Bound<'py, PyAny>> {
+    let tp = cls.as_type_ptr();
+    let ptr = unsafe {
+        let alloc = (*tp).tp_alloc.unwrap_or(ffi::PyType_GenericAlloc);
+        alloc(tp, 0)
+    };
+    if ptr.is_null() {
+        return Err(err_alloc_failed(cls.py()));
+    }
+    Ok(unsafe { Bound::from_owned_ptr(cls.py(), ptr) })
 }
 
 /// Set attribute via `PyObject_GenericSetAttr`, bypassing the type's `tp_setattro`.

--- a/src/python/py.rs
+++ b/src/python/py.rs
@@ -109,6 +109,22 @@ pub(crate) fn set_attr_unchecked(
     error_on_minusone(result)
 }
 
+/// Set attribute via `PyObject_GenericSetAttr`, bypassing the type's `tp_setattro`.
+///
+/// Used for frozen dataclasses: their `__setattr__` raises `FrozenInstanceError`,
+/// so fields must be written the way `object.__setattr__` would. Calling the C
+/// function directly skips the bound-method call machinery (argument tuple,
+/// wrapper descriptor) that `object.__setattr__(obj, name, value)` pays per field.
+#[inline]
+pub(crate) fn generic_set_attr(
+    obj: &Bound<PyAny>,
+    name: *mut ffi::PyObject,
+    value: Bound<PyAny>,
+) -> PyResult<()> {
+    let result = unsafe { ffi::PyObject_GenericSetAttr(obj.as_ptr(), name, value.as_ptr()) };
+    error_on_minusone(result)
+}
+
 #[inline(always)]
 pub(crate) fn create_py_tuple(py: Python, size: usize) -> PyResult<Bound<PyTuple>> {
     let size = cast_size(size).map_err(|_| err_size_overflow())?;

--- a/src/python/types.rs
+++ b/src/python/types.rs
@@ -160,7 +160,7 @@ impl EntityFieldInfo {
 
 #[derive(Clone, Debug)]
 pub struct EntityTypeInfo {
-    pub cls: Py<PyAny>,
+    pub cls: Py<PyType>,
     pub fields: Vec<EntityFieldInfo>,
     pub omit_none: bool,
     pub is_frozen: bool,
@@ -170,7 +170,7 @@ pub struct EntityTypeInfo {
 impl EntityTypeInfo {
     fn extract(type_info: &Bound<'_, PyAny>) -> PyResult<Self> {
         Ok(Self {
-            cls: type_info.getattr("cls")?.unbind(),
+            cls: type_info.getattr("cls")?.cast_into::<PyType>()?.unbind(),
             fields: extract_fields(type_info.getattr("fields")?)?,
             omit_none: type_info.getattr("omit_none")?.extract()?,
             is_frozen: type_info.getattr("is_frozen")?.extract()?,

--- a/src/serializer/encoders.rs
+++ b/src/serializer/encoders.rs
@@ -17,8 +17,8 @@ use uuid::Uuid;
 use crate::errors::{ToPyErr, ValidationError};
 use crate::python::{
     create_py_dict_known_size, create_py_list, create_py_tuple, dump_date, dump_datetime,
-    dump_time, parse_date, parse_datetime, parse_time, py_dict_set_item, py_list_get_item,
-    py_list_set_item, py_tuple_set_item, set_attr_unchecked,
+    dump_time, generic_set_attr, parse_date, parse_datetime, parse_time, py_dict_set_item,
+    py_list_get_item, py_list_set_item, py_tuple_set_item, set_attr_unchecked,
 };
 use crate::python::{DecimalTypeInfo, FloatTypeInfo, IntegerTypeInfo, StringTypeInfo};
 use crate::serde_error::{SerdeError, SerdeResult};
@@ -460,8 +460,6 @@ pub struct EntityEncoder {
     pub(crate) omit_none: bool,
     pub(crate) is_frozen: bool,
     pub(crate) fields: Vec<Field>,
-    pub(crate) create_object: Py<PyAny>,
-    pub(crate) object_set_attr: Py<PyAny>,
     pub(crate) used_keys: Py<PySet>,
 }
 
@@ -551,16 +549,20 @@ impl Encoder for EntityEncoder {
         let Ok(val) = value.cast::<PyDict>() else {
             invalid_type!("object", value, instance_path)
         };
-        let py_frozen_object_set_attr = self.object_set_attr.bind(value.py());
-        let obj = self
-            .create_object
-            .bind(value.py())
-            .call1((self.cls.bind(value.py()),))?;
+        let obj = unsafe {
+            let tp = self.cls.as_ptr() as *mut pyo3::ffi::PyTypeObject;
+            let alloc = (*tp).tp_alloc.unwrap_or(pyo3::ffi::PyType_GenericAlloc);
+            let ptr = alloc(tp, 0);
+            if ptr.is_null() {
+                return Err(PyErr::fetch(value.py()).into());
+            }
+            Bound::from_owned_ptr(value.py(), ptr)
+        };
 
         for field in &self.fields {
             let val = field.load_value(val, instance_path, ctx, &self.used_keys)?;
             if self.is_frozen {
-                py_frozen_object_set_attr.call1((&obj, &field.name, val))?;
+                generic_set_attr(&obj, field.name.as_ptr(), val)?;
             } else {
                 set_attr_unchecked(&obj, field.name.as_ptr(), val)?;
             };

--- a/src/serializer/encoders.rs
+++ b/src/serializer/encoders.rs
@@ -8,7 +8,7 @@ use nohash_hasher::IntMap;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::types::{
     PyBool, PyBytes, PyDate, PyDateTime, PyDict, PyFloat, PyInt, PyList, PySequence, PySet,
-    PyString, PyTime,
+    PyString, PyTime, PyType,
 };
 use pyo3::{intern, Bound, Py, PyAny, PyResult};
 use pyo3::{prelude::*, IntoPyObjectExt};
@@ -16,9 +16,9 @@ use uuid::Uuid;
 
 use crate::errors::{ToPyErr, ValidationError};
 use crate::python::{
-    create_py_dict_known_size, create_py_list, create_py_tuple, dump_date, dump_datetime,
-    dump_time, generic_set_attr, parse_date, parse_datetime, parse_time, py_dict_set_item,
-    py_list_get_item, py_list_set_item, py_tuple_set_item, set_attr_unchecked,
+    create_instance, create_py_dict_known_size, create_py_list, create_py_tuple, dump_date,
+    dump_datetime, dump_time, generic_set_attr, parse_date, parse_datetime, parse_time,
+    py_dict_set_item, py_list_get_item, py_list_set_item, py_tuple_set_item, set_attr_unchecked,
 };
 use crate::python::{DecimalTypeInfo, FloatTypeInfo, IntegerTypeInfo, StringTypeInfo};
 use crate::serde_error::{SerdeError, SerdeResult};
@@ -456,7 +456,7 @@ impl Encoder for ArrayEncoder {
 
 #[derive(Debug, Clone)]
 pub struct EntityEncoder {
-    pub(crate) cls: Py<PyAny>,
+    pub(crate) cls: Py<PyType>,
     pub(crate) omit_none: bool,
     pub(crate) is_frozen: bool,
     pub(crate) fields: Vec<Field>,
@@ -549,15 +549,7 @@ impl Encoder for EntityEncoder {
         let Ok(val) = value.cast::<PyDict>() else {
             invalid_type!("object", value, instance_path)
         };
-        let obj = unsafe {
-            let tp = self.cls.as_ptr() as *mut pyo3::ffi::PyTypeObject;
-            let alloc = (*tp).tp_alloc.unwrap_or(pyo3::ffi::PyType_GenericAlloc);
-            let ptr = alloc(tp, 0);
-            if ptr.is_null() {
-                return Err(PyErr::fetch(value.py()).into());
-            }
-            Bound::from_owned_ptr(value.py(), ptr)
-        };
+        let obj = create_instance(self.cls.bind(value.py()))?;
 
         for field in &self.fields {
             let val = field.load_value(val, instance_path, ctx, &self.used_keys)?;

--- a/src/serializer/main.rs
+++ b/src/serializer/main.rs
@@ -320,17 +320,10 @@ pub fn get_encoder(
             let fields =
                 iterate_on_fields(py, &type_info.fields, encoder_state, naive_datetime_to_utc)?;
 
-            let builtins = PyModule::import(py, intern!(py, "builtins"))?;
-            let object = builtins.getattr(intern!(py, "object"))?;
-            let create_object = object.getattr(intern!(py, "__new__"))?;
-            let object_set_attr = object.getattr("__setattr__")?;
-
             let encoder = EntityEncoder {
                 fields,
                 omit_none: type_info.omit_none,
                 is_frozen: type_info.is_frozen,
-                create_object: create_object.unbind(),
-                object_set_attr: object_set_attr.unbind(),
                 cls: type_info.cls.clone_ref(py),
                 used_keys: type_info.used_keys.clone_ref(py),
             };


### PR DESCRIPTION
## What

- **Bench**: add [msgspec](https://github.com/jcrist/msgspec) to the compare benchmarks in two modes: native `msgspec.Struct` and `msgspec.convert`/`to_builtins` over the shared dataclass model (apples-to-apples with serpyco-rs).
- **Perf**: two load-path optimizations found by analyzing msgspec's C internals:
  1. `EntityEncoder::load` allocates instances via the type's `tp_alloc` slot directly instead of calling `object.__new__(cls)` through Python call machinery (argument tuple + `PyObject_Call`). Same allocation path `object.__new__` takes internally, minus the call overhead; custom `tp_alloc` is respected, `PyType_GenericAlloc` is the fallback.
  2. Frozen dataclass fields are written via a direct `PyObject_GenericSetAttr` call instead of invoking `object.__setattr__` as a bound Python callable per field.

## Numbers

Compare benchmark (dataclass with 1000 nested items, CPython 3.13, arm64):

| | dump | load | frozen load |
|---|---|---|---|
| master | 33.7 µs | 46.3 µs | 51.4 µs |
| this PR | 33.9 µs | **33.7 µs (-27%)** | **33.6 µs (-35%)** |
| msgspec (Struct) | 30.8 µs | 30.6 µs | — |
| msgspec (dataclass) | 48.4 µs | 45.0 µs | — |

serpyco-rs now beats msgspec on identical dataclass models in both directions; the remaining ~10% gap vs Struct mode is the cost of producing real dataclass instances.

Also evaluated and rejected: boxing `SerdeError` variants (no measurable gain, regresses dump without `#[cold]` From impls) and a lockstep `__dict__` dump fast path (zero gain on 3.13 due to managed-dict materialization).