### PR TITLE
Perf: size msgpack containers from their header instead of regrowing per entry

### DIFF
--- a/src/format/bridge.rs
+++ b/src/format/bridge.rs
@@ -4,7 +4,7 @@ use pyo3::IntoPyObjectExt;
 
 use crate::errors::{ToPyErr, ValidationError};
 use crate::format::{Kind, ParsedInt, ParsedNumber, Parser, Writer};
-use crate::python::create_py_string;
+use crate::python::{create_py_dict_known_size, create_py_string};
 use crate::serde_error::{SchemaError, SerdeError, SerdeResult};
 use crate::validator::{Context, InstancePath};
 
@@ -100,6 +100,7 @@ pub(crate) fn parse_any<'py>(
         Kind::Array => {
             let mut items: Vec<Bound<'py, PyAny>> = Vec::new();
             if parser.enter_array_known()? {
+                items.reserve(parser.container_len_hint().unwrap_or(8));
                 loop {
                     items.push(parse_any(py, parser, ctx)?);
                     if !parser.next_array_item()? {
@@ -110,10 +111,13 @@ pub(crate) fn parse_any<'py>(
             Ok(PyList::new(py, items)?.into_any())
         }
         Kind::Map => {
-            let dict = PyDict::new(py);
             // Materializing the key ends its borrow of the parser buffer, freeing
             // the parser for the recursive value parse.
-            let mut key = parser.enter_map_known()?;
+            let (mut key, len_hint) = parser.enter_map_known_sized()?;
+            let dict = match len_hint {
+                Some(len) => create_py_dict_known_size(py, len)?,
+                None => PyDict::new(py),
+            };
             while let Some(k) = key {
                 let py_key = create_py_string(py, k)?;
                 let value = parse_any(py, parser, ctx)?;

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -410,6 +410,33 @@ impl<'j> Parser<'j> {
         }
     }
 
+    /// Entry count of the container just entered, when the format states it up front:
+    /// MessagePack headers do, JSON only reveals it at the closing bracket. Lets a
+    /// caller size its Python container once instead of regrowing it per entry.
+    #[inline(always)]
+    pub(crate) fn container_len_hint(&self) -> Option<usize> {
+        match self {
+            Parser::Json(_) => None,
+            Parser::Msgpack(p) => p.container_len_hint(),
+        }
+    }
+
+    /// [`enter_map_known`](Self::enter_map_known) paired with the entry count from
+    /// [`container_len_hint`](Self::container_len_hint). Both come out of one call
+    /// because the borrowed first key rules out a second one.
+    #[inline(always)]
+    pub(crate) fn enter_map_known_sized(
+        &mut self,
+    ) -> Result<(Option<&str>, Option<usize>), SerdeError> {
+        match self {
+            Parser::Json(p) => Ok((p.enter_map_known()?, None)),
+            Parser::Msgpack(p) => {
+                let (key, len) = p.enter_map_known_sized()?;
+                Ok((key, Some(len)))
+            }
+        }
+    }
+
     /// Enter an object without a preceding `peek()` (discriminated-union scan).
     #[inline]
     pub(crate) fn enter_map(&mut self) -> Result<Option<&str>, SerdeError> {

--- a/src/format/msgpack/parser.rs
+++ b/src/format/msgpack/parser.rs
@@ -183,6 +183,14 @@ impl<'a> MsgpackParser<'a> {
 
     #[inline(always)]
     pub(crate) fn enter_map_known(&mut self) -> Result<Option<&'a str>, SerdeError> {
+        self.enter_map_inner().map(|(key, _)| key)
+    }
+
+    /// `enter_map_known` that also reports the entry count, for a caller that sizes a
+    /// dict from it: the returned first key borrows the buffer, so it could not ask
+    /// afterwards. `0` means the map was empty.
+    #[inline(always)]
+    pub(crate) fn enter_map_known_sized(&mut self) -> Result<(Option<&'a str>, usize), SerdeError> {
         self.enter_map_inner()
     }
 
@@ -199,6 +207,28 @@ impl<'a> MsgpackParser<'a> {
         Ok(true)
     }
 
+    /// Entry count of the container the last `enter_*_known` opened, from its header.
+    /// Only valid right after entering — it is derived from the entries still pending,
+    /// so it shrinks as they are consumed.
+    #[inline(always)]
+    pub(crate) fn container_len_hint(&self) -> Option<usize> {
+        let container = self.containers.last()?;
+        Some(self.clamp_stated_len(container.kind, container.remaining as usize + 1))
+    }
+
+    /// A header can claim up to 2^32 entries that the input cannot possibly hold, and
+    /// the caller turns this count into an allocation, so the bytes left cap it: an
+    /// array entry costs at least one byte, a map pair at least two (an empty fixstr
+    /// key plus a one-byte value).
+    #[inline(always)]
+    fn clamp_stated_len(&self, kind: ContainerKind, stated: usize) -> usize {
+        let room = self.data.len() - self.index;
+        match kind {
+            ContainerKind::Array => stated.min(room + 1),
+            ContainerKind::Map => stated.min(room / 2 + 1),
+        }
+    }
+
     /// Enter a map without a preceding `peek()` (discriminated-union scan).
     #[inline]
     pub(crate) fn enter_map(&mut self) -> Result<Option<&'a str>, SerdeError> {
@@ -206,20 +236,21 @@ impl<'a> MsgpackParser<'a> {
         if self.peek()? != Kind::Map {
             return Err(self.err_at("expected map", pos));
         }
-        self.enter_map_inner()
+        self.enter_map_inner().map(|(key, _)| key)
     }
 
     #[inline(always)]
-    fn enter_map_inner(&mut self) -> Result<Option<&'a str>, SerdeError> {
+    fn enter_map_inner(&mut self) -> Result<(Option<&'a str>, usize), SerdeError> {
         let len = self.read_map_len()?;
         if len == 0 {
-            return Ok(None);
+            return Ok((None, 0));
         }
         self.containers.push(Container {
             kind: ContainerKind::Map,
             remaining: len - 1,
         });
-        self.take_map_key().map(Some)
+        let hint = self.clamp_stated_len(ContainerKind::Map, len as usize);
+        Ok((Some(self.take_map_key()?), hint))
     }
 
     #[inline(always)]

--- a/src/serializer/encoders.rs
+++ b/src/serializer/encoders.rs
@@ -920,10 +920,13 @@ impl Encoder for DictionaryEncoder {
         if parser.peek()? != Kind::Map {
             return Err(wrong_type_at_cursor(parser, "dict", instance_path));
         }
-        let result_dict = PyDict::new(py);
         // Materializing the key ends its borrow of the parser buffer and then
         // serves both instance_path and the insert.
-        let mut key_opt = parser.enter_map_known()?;
+        let (mut key_opt, len_hint) = parser.enter_map_known_sized()?;
+        let result_dict = match len_hint {
+            Some(len) => create_py_dict_known_size(py, len)?,
+            None => PyDict::new(py),
+        };
         while let Some(k) = key_opt {
             let py_key = create_py_string(py, k)?;
             let key_any = py_key.as_any();
@@ -1056,8 +1059,9 @@ impl Encoder for ArrayEncoder {
         let mut items: Vec<Bound<'py, PyAny>> = Vec::new();
         if parser.enter_array_known()? {
             // One allocation instead of the regrowth ladder; empty arrays never
-            // reach here and stay allocation-free.
-            items.reserve(8);
+            // reach here and stay allocation-free. A format that states its length
+            // (MessagePack) sizes this exactly — 8 is the guess for one that doesn't.
+            items.reserve(parser.container_len_hint().unwrap_or(8));
             loop {
                 // Length is only known at the closing bracket, so an element-type
                 // error surfaces before a length error (dict path checks length up front).

--- a/tests/test_codec_msgpack.py
+++ b/tests/test_codec_msgpack.py
@@ -124,6 +124,38 @@ def test_malformed_msgpack_raises_decode_error(raw):
     assert isinstance(exc.value.position, int)
 
 
+@pytest.mark.parametrize('tp', [Any, list[int], dict[str, int]])
+@pytest.mark.parametrize(
+    'raw',
+    [
+        b'\xdd\xff\xff\xff\xff',  # array32 claiming 2**32-1 entries, no payload
+        b'\xdf\xff\xff\xff\xff',  # map32, same
+    ],
+)
+def test_msgpack_oversized_container_header_is_not_preallocated(tp, raw):
+    # The header count sizes the Python container up front, so a claim the input cannot
+    # back must be capped by the bytes left — reserving 2**32-1 entries would abort the
+    # process long before the truncated payload is reported.
+    with pytest.raises(serpyco_rs.DecodeError):
+        Serializer(tp, codec=MSGPACK).load(raw)
+
+
+@pytest.mark.parametrize('size', [0, 1, 15, 16, 100, 65535, 65536])
+def test_msgpack_container_roundtrip_across_header_forms(size):
+    # fixarray/fixmap, array16/map16 and array32/map32 state their length differently;
+    # the presize path has to read each form correctly.
+    lst = Serializer(list[int], codec=MSGPACK)
+    values = list(range(size))
+    assert lst.load(lst.dump(values)) == values
+
+    dct = Serializer(dict[str, int], codec=MSGPACK)
+    mapping = {str(i): i for i in range(size)}
+    assert dct.load(dct.dump(mapping)) == mapping
+
+    any_codec = Serializer(Any, codec=MSGPACK)
+    assert any_codec.load(any_codec.dump(mapping)) == mapping
+
+
 def test_msgpack_rejects_trailing_data():
     serializer = Serializer(int, codec=MSGPACK)
     with pytest.raises(serpyco_rs.DecodeError, match='trailing data'):


### PR DESCRIPTION
## Summary

A MessagePack header states how many entries a container holds, but the parser dropped that number — `enter_array_known` returned only "has a first element", so `ArrayEncoder::load_format` walked the regrowth ladder (8 → 16 → … → 1024 for a 1000-element list) and `DictionaryEncoder::load_format` let CPython resize the dict table on the way. JSON has no such number (it only shows up at the closing bracket), so the hint is `Option` and JSON keeps the old behaviour.

The length now reaches the four places that build a Python container: `ArrayEncoder::load_format`, `DictionaryEncoder::load_format`, and both containers in `bridge::parse_any`. Map needed its own entry point (`enter_map_known_sized`) because the borrowed first key rules out asking the parser a second time.

## Measurements

Cachegrind on the x86 verification VM, `PYTHONHASHSEED=0`, 20 000 iterations per driver (numbers include ~0.47e9 instructions of CPython startup in both columns):

| load | base | head | Ir |
| --- | ---: | ---: | ---: |
| `dict[str, int]`, 1000 pairs | 22,928,849,250 | 21,579,269,095 | **−5.89%** |
| `Any` (list of 500 + dict of 200) | 6,881,086,000 | 6,584,765,992 | **−4.31%** |
| `list[int]`, 1000 | 6,363,931,271 | 6,280,911,475 | **−1.30%** |

`cg_annotate --diff` attributes the list delta to the malloc subsystem (−60.2M across `_int_malloc`/`_int_realloc`/`realloc`/`_int_free*`), `__memcpy_avx_unaligned_erms` (−12.1M) and the Rust ladder itself (`RawVecInner::finish_grow` −6.2M, `RawVec::grow_one` −3.4M). `ArrayEncoder::load_format` pays 160K more for asking the hint.

The dict delta is larger by an order of magnitude because a 1000-key table is rebuilt ~7 times without a presize: `__memcpy_avx_unaligned_erms` −242.7M and `__memset_avx2_unaligned_erms` −174.6M disappear.

## Why the count is clamped

The stated count feeds an allocation, and `array32`/`map32` can claim 2^32-1 entries in five bytes. The bytes left cap it: an array entry costs at least one byte, a map pair at least two. Without the clamp those five bytes are enough to kill the process — on Linux with 3 GiB RAM and `overcommit_memory=0`:

```
Fatal Python error: Aborted
  File "python/serpyco_rs/_main.py", line 168 in load
  File "tests/test_codec_msgpack.py", line 140 in test_msgpack_oversized_container_header_is_not_preallocated
```

Worth knowing for anyone touching that test: it cannot fail on macOS, where reserving 34 GiB succeeds virtually and the pages are never touched. It only guards on Linux.

https://claude.ai/code/session_019sNFFu5ZfrqLsvHcyWUmr2
