### PR TITLE
Dependabot: less noise — monthly grouped updates, ignore num-bigint majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,32 @@
 version: 2
+# Scheduled updates are monthly and grouped; security fixes come through a
+# separate channel (automated-security-fixes) that this schedule does not delay.
 updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      cargo:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      # pyo3 and jiter require num-bigint ^0.4: our BigInt must be their type,
+      # otherwise IntoPyObject is lost. Drop once upstream moves to 0.5 (#280).
+      - dependency-name: "num-bigint"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      python:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
Two changes to cut dependabot noise:

**Monthly + grouped.** Weekly per-dependency PRs generated a lot of churn (7 open at once). All three ecosystems move to `monthly`, and version updates are grouped into one PR per ecosystem (cargo/pip grouped for minor+patch, github-actions for everything). Security fixes are unaffected: they come through `automated-security-fixes` (verified enabled, not paused), which ignores `schedule.interval`, so a vulnerability still lands a PR the day it is published. Cargo majors stay ungrouped so they keep arriving as individual, reviewable PRs.

**Ignore num-bigint majors.** Both pyo3 0.29.2 and jiter 0.16.0 require `num-bigint ^0.4.4`, so our direct dependency has to stay on the same 0.4 type: with 0.5 the tree ends up with two incompatible `BigInt` types and `ParsedInt::Big(BigInt)` loses `IntoPyObject` (E0599 in 5 places) while `src/format/json/parser.rs:64` stops type-checking against jiter (E0308). Unmergeable until upstream moves to 0.5 — #280 closed, and the major is ignored so the bot stops reopening it.

https://claude.ai/code/session_01HuZyGyvdrocKyThmrvVR9d