### PR TITLE
Add Python 3.15 support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,6 +33,8 @@ jobs:
           - "3.13"
           - "3.14"
           - "3.14t"
+          - "3.15"
+          - "3.15t"
         include:
           - os: macos-latest
             target: universal2-apple-darwin
@@ -150,7 +152,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           manylinux: auto
           docker-options: ${{ matrix.platform.maturin_docker_options }}
-          args: --release --sdist -o dist --interpreter 3.10 3.11 3.12 3.13 3.14 3.14t
+          args: --release --sdist -o dist --interpreter 3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t
           sccache: "true"
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -164,7 +166,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15", "3.15t"]
 
     name: Test on ${{ matrix.os}} ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}

--- a/bench/compare/test_github_issue_bytes.py
+++ b/bench/compare/test_github_issue_bytes.py
@@ -17,7 +17,7 @@ LIBS = (
 
 
 # Resolved per test rather than at import time: the PGO profile run selects the
-# codec contenders only, and it runs in the build matrix (3.10 … 3.14t) where the
+# codec contenders only, and it runs in the build matrix (3.10 … 3.15t) where the
 # comparison libs are not installed.
 #
 # ``wire`` converts the JSON fixture into the contender's native byte form

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python",
     "Programming Language :: Rust",
@@ -56,7 +57,7 @@ bench = [
     "pytest-benchmark[histogram]",
     "tabulate",
 ]
-# Installed in every build-matrix job (3.10 … 3.14t), so it must stay light: libs
+# Installed in every build-matrix job (3.10 … 3.15t), so it must stay light: libs
 # like orjson lack wheels for some of those interpreters and would build from source.
 pgo = [
     { include-group = "bench" },

--- a/python/serpyco_rs/_describe.py
+++ b/python/serpyco_rs/_describe.py
@@ -1,4 +1,5 @@
 import dataclasses
+import re
 import sys
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from datetime import date, datetime, time
@@ -611,13 +612,43 @@ def _generate_name(cls: Any, ref: str) -> str:
     We need unique name to avoid name conflicts in generated json schema,
     when we have one entity with different Annotated metadata (like FieldFormat).
     """
-    name = repr(cls).removeprefix("<class '").removesuffix("'>")
+    name = _type_repr(cls).removeprefix("<class '").removesuffix("'>")
     if name not in _NAME_CACHE:
         _NAME_CACHE[name] = 0
         return name
 
     _NAME_CACHE[name] += 1
     return f'{name}{_NAME_CACHE[name]}'
+
+
+def _type_repr(t: Any) -> str:
+    """Keep PEP 695 type alias names stable across supported Python versions.
+
+    Python 3.15 qualifies aliases nested in another type with their module and
+    qualname, while older versions use the short alias name.
+    """
+    result = repr(t)
+    pending = [t]
+    seen: set[int] = set()
+
+    while pending:
+        item = pending.pop()
+        if id(item) in seen:
+            continue
+        seen.add(id(item))
+
+        origin = get_origin(item)
+        alias = item if is_typealiastype(item) else origin if is_typealiastype(origin) else None
+        if alias is not None:
+            module = getattr(alias, '__module__', None)
+            qualname = getattr(alias, '__qualname__', None)
+            if module and qualname:
+                qualified_name = re.escape(f'{module}.{qualname}')
+                result = re.sub(rf'(?<![\w.]){qualified_name}(?![\w.])', repr(alias), result)
+
+        pending.extend(get_args(item))
+
+    return result
 
 
 def _get_globals(t: Any) -> dict[str, Any]:

--- a/src/python/py.rs
+++ b/src/python/py.rs
@@ -66,7 +66,7 @@ pub(crate) fn py_list_set_item(list: &Bound<PyList>, index: usize, value: Bound<
 }
 
 // Private CPython API: the binding was removed from pyo3-ffi 0.28+, but the
-// symbol is still exported by all supported CPython versions (incl. 3.14t).
+// symbol is still exported by all supported CPython versions (incl. 3.15t).
 // On Windows this needs the import library, which pyo3 0.29+ no longer links
 // (raw-dylib) — build.rs restores it.
 extern "C" {

--- a/src/python/slots.rs
+++ b/src/python/slots.rs
@@ -46,7 +46,7 @@ use pyo3_ffi::Py_ssize_t;
 use super::py::{create_instance, generic_set_attr};
 
 /// `PyMemberDef` from CPython's `object.h`; the layout is stable across
-/// 3.10 … 3.14 and is what a `__slots__` descriptor points at.
+/// 3.10 … 3.15 and is what a `__slots__` descriptor points at.
 #[repr(C)]
 struct PyMemberDef {
     name: *const std::os::raw::c_char,


### PR DESCRIPTION
## Summary
- build and test wheels on CPython 3.15 and free-threaded 3.15t across the existing platform matrix
- include both interpreters in cross-platform release builds and advertise the Python 3.15 classifier
- keep recursive PEP 695 type-alias schema names stable after Python 3.15 started qualifying nested aliases

## Testing
- Python 3.15.0b4: 934 passed
- Python 3.15.0b4 free-threaded: 934 passed
- cargo check on 3.15 and 3.15t
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- ruff format --check and ruff check